### PR TITLE
feat: Strip leading h1 from autoReadme content to avoid duplication

### DIFF
--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -152,5 +152,5 @@ When both config files exist, Docula loads them in this order (first found wins)
 | `apiPath` | `string` | `'api'` | Output subdirectory and URL segment for API reference pages. |
 | `changelogPath` | `string` | `'changelog'` | Output subdirectory and URL segment for changelog pages. |
 | `googleTagManager` | `string` | - | Google Tag Manager container ID (e.g., `'GTM-XXXXXX'`) or Google Analytics 4 measurement ID (e.g., `'G-XXXXXXXXXX'`). Injects the appropriate tracking script on every page. |
-| `autoReadme` | `boolean` | `true` | Automatically use the project root `README.md` as the home page when no `README.md` exists in the site directory. Set to `false` to disable this fallback. |
+| `autoReadme` | `boolean` | `true` | Automatically use the project root `README.md` as the home page when no `README.md` exists in the site directory. The leading `# Title` heading is stripped from the rendered page to avoid duplicating the site title. Set to `false` to disable this fallback. |
 | `allowedAssets` | `string[]` | *(see [Assets & Public Folder](/docs/assets))* | File extensions to copy from `docs/` and `changelog/` to output |

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -81,6 +81,6 @@ Subdirectories inside `docs/` automatically become sections in the sidebar navig
 
 Docula automatically detects what content exists and picks the starting view for your site:
 
-- **README.md exists** — A dedicated landing page renders at `/` using `home.hbs`, and docs are available at `/docs/`. Docula looks for a `README.md` in your site folder first, then falls back to your project root `README.md` via the `autoReadme` option.
+- **README.md exists** — A dedicated landing page renders at `/` using `home.hbs`, and docs are available at `/docs/`. Docula looks for a `README.md` in your site folder first, then falls back to your project root `README.md` via the `autoReadme` option. When using `autoReadme`, the leading `# Title` heading is automatically stripped from the rendered page to avoid duplicating the site title.
 - **No README.md, but docs exist** — The first doc page renders directly as `/index.html`.
 - **No README.md, no docs, but `api/swagger.json` exists** — The API page renders as `/index.html`.

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1032,7 +1032,10 @@ export class DoculaBuilder {
 	public async buildReadmeSection(data: DoculaData): Promise<string> {
 		let htmlReadme = "";
 		if (data.readmeContent !== undefined) {
-			htmlReadme = await new Writr(data.readmeContent, writrOptions).render();
+			// Strip leading h1 heading so the rendered single-page does not
+			// duplicate the site title already present in the <title> tag.
+			const content = data.readmeContent.replace(/^\s*#\s+.+\n*/, "");
+			htmlReadme = await new Writr(content, writrOptions).render();
 		} else if (fs.existsSync(`${data.sitePath}/README.md`)) {
 			const readmeContent = fs.readFileSync(
 				`${data.sitePath}/README.md`,

--- a/test/builder-documents.test.ts
+++ b/test/builder-documents.test.ts
@@ -447,6 +447,37 @@ describe("DoculaBuilder - Documents", () => {
 
 			expect(result).toBeTruthy();
 		});
+
+		it("should strip leading h1 from autoReadme content", async () => {
+			const builder = new DoculaBuilder(
+				Object.assign(new DoculaOptions(), { quiet: true }),
+			);
+			const data = {
+				...doculaData,
+				readmeContent: "# My Title\n\nSome body content.",
+			};
+
+			const result = await builder.buildReadmeSection(data);
+
+			expect(result).not.toContain("<h1");
+			expect(result).toContain("Some body content");
+		});
+
+		it("should not strip h1 when readmeContent is not set", async () => {
+			const builder = new DoculaBuilder(
+				Object.assign(new DoculaOptions(), { quiet: true }),
+			);
+			const data = {
+				...doculaData,
+				sitePath: "test/fixtures/single-page-site",
+				readmeContent: undefined,
+			};
+
+			const result = await builder.buildReadmeSection(data);
+
+			expect(result).toBeTruthy();
+			expect(result).toContain("<h1");
+		});
 	});
 
 	describe("Build Announcement Section", async () => {

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -3227,7 +3227,10 @@ describe("DoculaBuilder", () => {
 					`${options.output}/index.html`,
 					"utf8",
 				);
-				expect(indexHtml).toContain("My Project");
+				expect(indexHtml).toContain("Welcome to the project");
+				// The h1 title from the README should be stripped to avoid
+				// duplicating the site title already in the <title> tag.
+				expect(indexHtml).not.toContain("<h1>My Project</h1>");
 				// The root README should NOT have been copied into the site path
 				expect(fs.existsSync("test/fixtures/auto-readme-site/README.md")).toBe(
 					false,


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**Description**
When `readmeContent` is provided (auto-generated README), the leading h1 heading is now stripped before rendering. This prevents the site title from being duplicated in the rendered output, since the title is already present in the `<title>` tag.

The fix:
- Adds a regex replacement to remove the leading h1 heading (`^\s*#\s+.+\n*`) from `readmeContent` before rendering
- Only applies when `readmeContent` is explicitly set; file-based README.md files are unaffected
- Preserves all other content in the README

**Testing**
- Added test case "should strip leading h1 from autoReadme content" to verify h1 removal when `readmeContent` is set
- Added test case "should not strip h1 when readmeContent is not set" to verify file-based READMEs are unaffected
- Updated existing test assertion to verify the h1 title is not duplicated in the rendered output
- All tests pass with 100% code coverage for the changes

https://claude.ai/code/session_01JWdvmT49eV9EHjCwbkbQXU