### PR TITLE
feat: add onAutoReadme hook to transform resolved README content

### DIFF
--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -107,9 +107,40 @@ Each `DoculaChangelogEntry` has these fields you can read or modify:
 
 The hook can be synchronous or async. If the hook throws an error, it is logged and the unmodified entries are used.
 
+## Cleaning Up the Auto README
+
+When `autoReadme` is enabled and docula falls back to your project root `README.md` for the home page, the `onAutoReadme` hook lets you transform that markdown before it is rendered. This is useful for stripping a shields/badges banner, removing an "Install" section that doesn't belong on the home page, or rewriting relative links.
+
+```typescript
+import type { DoculaConsole, DoculaOptions } from 'docula';
+
+export const options: Partial<DoculaOptions> = {
+  autoReadme: true,
+};
+
+export const onAutoReadme = (content: string, sourcePath: string, console: DoculaConsole): string => {
+  console.info(`Cleaning up README at ${sourcePath}`);
+  return content
+    // Drop everything from "## Install" up to the next H2
+    .replace(/^##\s+Install[\s\S]*?(?=^##\s)/m, '')
+    // Rewrite relative links to absolute
+    .replace(/\]\(\.\//g, '](https://github.com/your-username/your-repo/blob/main/');
+};
+```
+
+The hook receives:
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `content` | `string` | The resolved README markdown (with a `# name` title prepended if the README had none) |
+| `sourcePath` | `string` | Absolute path of the root `README.md` |
+| `console` | `DoculaConsole` | Logger (see below) |
+
+The hook can be synchronous or async and must return the new markdown. If the hook throws, the error is logged and the original content is used. The hook only runs when `autoReadme` is enabled and there is no `README.md` in the site directory.
+
 ## DoculaConsole Logger
 
-Both `onPrepare` and `onReleaseChangelog` hooks receive a `DoculaConsole` instance as their second argument. This provides styled, consistent logging output:
+The `onPrepare`, `onReleaseChangelog`, and `onAutoReadme` hooks all receive a `DoculaConsole` instance as their last argument. This provides styled, consistent logging output:
 
 | Method | Description |
 |--------|-------------|

--- a/src/builder-cache.ts
+++ b/src/builder-cache.ts
@@ -48,6 +48,17 @@ export function hashFile(hash: Hashery, filePath: string): string {
 	return hash.toHashSync(content);
 }
 
+export function hashConfigFile(hash: Hashery, sitePath: string): string {
+	for (const name of ["docula.config.ts", "docula.config.mjs"]) {
+		const configPath = path.join(sitePath, name);
+		if (fs.existsSync(configPath)) {
+			return hashFile(hash, configPath);
+		}
+	}
+
+	return "";
+}
+
 export function hashOptions(hash: Hashery, options: DoculaOptions): string {
 	const relevant = {
 		siteUrl: options.siteUrl,
@@ -74,7 +85,9 @@ export function hashOptions(hash: Hashery, options: DoculaOptions): string {
 		ai: options.ai,
 		googleTagManager: options.googleTagManager,
 	};
-	return hash.toHashSync(JSON.stringify(relevant));
+	const optionsHash = hash.toHashSync(JSON.stringify(relevant));
+	const configHash = hashConfigFile(hash, options.sitePath);
+	return hash.toHashSync(`${optionsHash}:${configHash}`);
 }
 
 export function hashTemplateDirectory(

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -828,7 +828,8 @@ export class DoculaBuilder {
 					this._console,
 				);
 			} catch (error) {
-				this._console.error(`onAutoReadme error: ${(error as Error).message}`);
+				const message = error instanceof Error ? error.message : String(error);
+				this._console.error(`onAutoReadme error: ${message}`);
 			}
 		}
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -115,6 +115,11 @@ export class DoculaBuilder {
 		entries: DoculaChangelogEntry[],
 		console: DoculaConsole,
 	) => Promise<DoculaChangelogEntry[]> | DoculaChangelogEntry[];
+	public onAutoReadme?: (
+		content: string,
+		sourcePath: string,
+		console: DoculaConsole,
+	) => Promise<string> | string;
 
 	public get console(): DoculaConsole {
 		return this._console;
@@ -814,7 +819,20 @@ export class DoculaBuilder {
 			}
 		}
 
-		return { sourcePath: cwdReadmePath, content: readmeContent };
+		let content = readmeContent;
+		if (this.onAutoReadme) {
+			try {
+				content = await this.onAutoReadme(
+					content,
+					cwdReadmePath,
+					this._console,
+				);
+			} catch (error) {
+				this._console.error(`onAutoReadme error: ${(error as Error).message}`);
+			}
+		}
+
+		return { sourcePath: cwdReadmePath, content };
 	}
 
 	public async getGithubData(githubPath: string): Promise<GithubData> {

--- a/src/docula.ts
+++ b/src/docula.ts
@@ -310,6 +310,11 @@ export default class Docula {
 			builder.onReleaseChangelog = this._configFileModule.onReleaseChangelog;
 		}
 
+		/* v8 ignore next 4 -- @preserve */
+		if (this._configFileModule.onAutoReadme) {
+			builder.onAutoReadme = this._configFileModule.onAutoReadme;
+		}
+
 		await builder.build();
 		return builder;
 	}

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -3381,5 +3381,75 @@ describe("DoculaBuilder", () => {
 
 			expect(hashA).not.toEqual(hashB);
 		});
+
+		it("should produce different hashes when docula.config.mjs changes", () => {
+			const tempDir = "test/temp/hash-config-change";
+			fs.mkdirSync(tempDir, { recursive: true });
+			const configPath = `${tempDir}/docula.config.mjs`;
+
+			try {
+				const options = new DoculaOptions();
+				options.quiet = true;
+				options.sitePath = tempDir;
+
+				fs.writeFileSync(configPath, "export const onAutoReadme = (c) => c;\n");
+				const hashBefore = hashOptionsUtil(testHash, options);
+
+				fs.writeFileSync(
+					configPath,
+					"export const onAutoReadme = (c) => c.toUpperCase();\n",
+				);
+				const hashAfter = hashOptionsUtil(testHash, options);
+
+				expect(hashBefore).not.toEqual(hashAfter);
+			} finally {
+				removeTempDir(tempDir);
+			}
+		});
+
+		it("should return the same hash when no config file exists", () => {
+			const tempDir = "test/temp/hash-config-missing";
+			fs.mkdirSync(tempDir, { recursive: true });
+
+			try {
+				const options = new DoculaOptions();
+				options.quiet = true;
+				options.sitePath = tempDir;
+
+				const hashA = hashOptionsUtil(testHash, options);
+				const hashB = hashOptionsUtil(testHash, options);
+
+				expect(hashA).toEqual(hashB);
+			} finally {
+				removeTempDir(tempDir);
+			}
+		});
+
+		it("should prefer docula.config.ts over docula.config.mjs", () => {
+			const tempDir = "test/temp/hash-config-priority";
+			fs.mkdirSync(tempDir, { recursive: true });
+
+			try {
+				const options = new DoculaOptions();
+				options.quiet = true;
+				options.sitePath = tempDir;
+
+				fs.writeFileSync(
+					`${tempDir}/docula.config.mjs`,
+					"export const a = 1;\n",
+				);
+				const hashMjsOnly = hashOptionsUtil(testHash, options);
+
+				fs.writeFileSync(
+					`${tempDir}/docula.config.ts`,
+					"export const a = 2;\n",
+				);
+				const hashWithTs = hashOptionsUtil(testHash, options);
+
+				expect(hashMjsOnly).not.toEqual(hashWithTs);
+			} finally {
+				removeTempDir(tempDir);
+			}
+		});
 	});
 });

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -3187,6 +3187,83 @@ describe("DoculaBuilder", () => {
 			cwdSpy.mockRestore();
 		});
 
+		it("should invoke onAutoReadme hook to transform content", async () => {
+			const resolvedCwd = path.resolve(tempCwdPath);
+			const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(resolvedCwd);
+			fs.writeFileSync(
+				`${tempCwdPath}/README.md`,
+				"# Project\n\nSome content here",
+			);
+
+			const options = new DoculaOptions();
+			options.quiet = true;
+			options.sitePath = tempSitePath;
+			options.autoReadme = true;
+			const builder = new DoculaBuilder(options);
+			builder.onAutoReadme = (content, sourcePath) => {
+				expect(sourcePath).toEqual(path.join(resolvedCwd, "README.md"));
+				return content.replace("Some content here", "CLEANED");
+			};
+
+			const result = await builder.autoReadme();
+
+			expect(result?.content).toContain("CLEANED");
+			expect(result?.content).not.toContain("Some content here");
+
+			cwdSpy.mockRestore();
+		});
+
+		it("should support async onAutoReadme hook", async () => {
+			const cwdSpy = vi
+				.spyOn(process, "cwd")
+				.mockReturnValue(path.resolve(tempCwdPath));
+			fs.writeFileSync(`${tempCwdPath}/README.md`, "# Project\n\nBody");
+
+			const options = new DoculaOptions();
+			options.quiet = true;
+			options.sitePath = tempSitePath;
+			const builder = new DoculaBuilder(options);
+			builder.onAutoReadme = async (content) =>
+				`${content}\n\nAppended by hook`;
+
+			const result = await builder.autoReadme();
+
+			expect(result?.content).toContain("Appended by hook");
+
+			cwdSpy.mockRestore();
+		});
+
+		it("should catch onAutoReadme errors and keep original content", async () => {
+			const cwdSpy = vi
+				.spyOn(process, "cwd")
+				.mockReturnValue(path.resolve(tempCwdPath));
+			fs.writeFileSync(
+				`${tempCwdPath}/README.md`,
+				"# Project\n\nOriginal body",
+			);
+
+			const options = new DoculaOptions();
+			options.quiet = true;
+			options.sitePath = tempSitePath;
+			const builder = new DoculaBuilder(options);
+			const errorSpy = vi
+				.spyOn(builder.console, "error")
+				.mockImplementation(() => {});
+			builder.onAutoReadme = () => {
+				throw new Error("hook boom");
+			};
+
+			const result = await builder.autoReadme();
+
+			expect(result?.content).toEqual("# Project\n\nOriginal body");
+			expect(errorSpy).toHaveBeenCalledWith(
+				expect.stringContaining("onAutoReadme error: hook boom"),
+			);
+
+			errorSpy.mockRestore();
+			cwdSpy.mockRestore();
+		});
+
 		it("should not copy README or referenced images into sitePath", async () => {
 			const cwdSpy = vi
 				.spyOn(process, "cwd")

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -3264,6 +3264,34 @@ describe("DoculaBuilder", () => {
 			cwdSpy.mockRestore();
 		});
 
+		it("should handle non-Error throws from onAutoReadme", async () => {
+			const cwdSpy = vi
+				.spyOn(process, "cwd")
+				.mockReturnValue(path.resolve(tempCwdPath));
+			fs.writeFileSync(`${tempCwdPath}/README.md`, "# Project\n\nBody");
+
+			const options = new DoculaOptions();
+			options.quiet = true;
+			options.sitePath = tempSitePath;
+			const builder = new DoculaBuilder(options);
+			const errorSpy = vi
+				.spyOn(builder.console, "error")
+				.mockImplementation(() => {});
+			builder.onAutoReadme = () => {
+				throw "string failure";
+			};
+
+			const result = await builder.autoReadme();
+
+			expect(result?.content).toEqual("# Project\n\nBody");
+			expect(errorSpy).toHaveBeenCalledWith(
+				expect.stringContaining("onAutoReadme error: string failure"),
+			);
+
+			errorSpy.mockRestore();
+			cwdSpy.mockRestore();
+		});
+
 		it("should not copy README or referenced images into sitePath", async () => {
 			const cwdSpy = vi
 				.spyOn(process, "cwd")


### PR DESCRIPTION
Mirrors the onReleaseChangelog pattern so users can register a
(content, sourcePath, console) => string | Promise<string> hook in
docula.config.{ts,mjs} to clean up the root README before it becomes
the home page (strip banners, rewrite links, etc.). Errors in the hook
are caught and logged; original content is preserved.