### PR TITLE
fix: zoom-in cursor for images inside links

### DIFF
--- a/templates/modern/css/styles.css
+++ b/templates/modern/css/styles.css
@@ -398,7 +398,7 @@ body {
 .copy-code-btn { position: absolute; top: 8px; right: 8px; padding: 4px; line-height: 0; border-radius: 4px; background: transparent; color: var(--muted); border: none; cursor: pointer; opacity: 0; transition: opacity 0.15s; }
 pre:hover .copy-code-btn { opacity: 1; }
 .copy-code-btn:hover { color: var(--fg); }
-.article__main img, .changelog-entry-body img { cursor: zoom-in; }
+.article__main img:not(a img), .changelog-entry-body img:not(a img) { cursor: zoom-in; }
 .lightbox-overlay { display: none; position: fixed; inset: 0; z-index: 200; background: rgba(0, 0, 0, 0.8); justify-content: center; align-items: center; cursor: pointer; }
 .lightbox-overlay--visible { display: flex !important; }
 .lightbox-overlay img { max-width: 90vw; max-height: 90vh; border-radius: 8px; box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4); cursor: default; }

--- a/templates/modern/includes/scripts.hbs
+++ b/templates/modern/includes/scripts.hbs
@@ -324,6 +324,7 @@
     document.body.appendChild(lightboxOverlay);
 
     document.querySelectorAll('.article__main img, .changelog-entry-body img').forEach(function(img) {
+      if (img.closest('a')) return;
       img.addEventListener('click', function() {
         lightboxImg.src = img.src;
         lightboxOverlay.classList.add('lightbox-overlay--visible');


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**Description**
This PR fixes an issue where images nested inside anchor tags (`<a>`) were incorrectly showing the zoom-in cursor and triggering the lightbox overlay when clicked. Since these images are already clickable links, they should not have the zoom-in interaction applied.

**Changes**
- Updated CSS selector to exclude images inside links using `:not(a img)` pseudo-class
- Added JavaScript check to skip lightbox event listener attachment for images inside anchor tags

This ensures that only standalone images (not wrapped in links) display the zoom-in cursor and open the lightbox on click, while linked images maintain their default link behavior.

**Test Plan**
- Verify that standalone images in articles show zoom-in cursor and open lightbox on click
- Verify that images inside links do not show zoom-in cursor and navigate to the link destination on click

https://claude.ai/code/session_01WNmhZAEwRha4oAFr35eaNB