### PR TITLE
fix(binary): skip site config loading for `version` command

### DIFF
--- a/src/docula.ts
+++ b/src/docula.ts
@@ -135,6 +135,12 @@ export default class Docula {
 			return;
 		}
 
+		// Short-circuit for version — no config needed
+		if (consoleProcess.command === "version") {
+			this._console.log(this.getVersion());
+			return;
+		}
+
 		// Update options
 		if (consoleProcess.args.sitePath) {
 			this.options.sitePath = consoleProcess.args.sitePath;
@@ -154,12 +160,6 @@ export default class Docula {
 		// Propagate quiet setting to console
 		if (this.options.quiet) {
 			this._console.quiet = true;
-		}
-
-		// Short-circuit for version — after config but before onPrepare
-		if (consoleProcess.command === "version") {
-			this._console.log(this.getVersion());
-			return;
 		}
 
 		// Run the onPrepare function
@@ -462,10 +462,11 @@ export default class Docula {
 				try {
 					const mod = await import(fileUrl);
 					this._configFileModule = mod.default ?? mod;
-				} catch {
+				} catch (error) {
 					throw new Error(
-						"TypeScript config files require Node.js 22.6.0 or later when using the standalone binary. " +
-							"Please upgrade Node.js or use docula.config.mjs instead.",
+						`Failed to load TypeScript config file from standalone binary: ${(error as Error).message}. ` +
+							"TypeScript config files require Node.js 22.6.0 or later when using the standalone binary. " +
+							"If you are on a supported Node.js version, try using docula.config.mjs instead.",
 					);
 				}
 			} else {

--- a/test/docula.test.ts
+++ b/test/docula.test.ts
@@ -702,6 +702,23 @@ describe("docula execute", () => {
 		expect(consoleMessage).toContain(".");
 		console.log = consoleLog;
 	});
+	it("should show version without loading the site config", async () => {
+		const docula = new Docula(cloneDefaultOptions(false));
+		docula.options.sitePath = "test/fixtures/multi-page-site";
+		const consoleLog = console.log;
+		let consoleMessage = "";
+		process.argv = ["node", "docula", "version"];
+		console.log = (message) => {
+			if (typeof message === "string") {
+				consoleMessage = message;
+			}
+		};
+
+		await docula.execute(process);
+		expect(consoleMessage).toContain(".");
+		expect(docula.configFileModule).toEqual({});
+		console.log = consoleLog;
+	});
 	it("should serve the site", async () => {
 		const options = new DoculaOptions();
 		options.sitePath = "test/fixtures/single-page-site";
@@ -1446,20 +1463,10 @@ describe("docula config file", () => {
 		await docula.loadConfigFile(sitePath);
 		expect(docula.configFileModule).toBeDefined();
 		expect(docula.configFileModule.options).toBeDefined();
-		const consoleLog = console.log;
-		let _consoleMessage = "";
-		console.log = (message) => {
-			if (typeof message === "string") {
-				_consoleMessage = message;
-			}
-		};
-
-		process.argv = ["node", "docula", "version"];
-		await docula.execute(process);
+		docula.options.parseOptions(docula.configFileModule.options);
 		expect(docula.options.output).toEqual(
 			path.resolve(process.cwd(), docula.configFileModule.options.output),
 		);
-		console.log = consoleLog;
 	});
 	it("should build docs at root when no README.md exists", async () => {
 		const options = new DoculaOptions();


### PR DESCRIPTION
## Summary

The `build-binaries` workflow (Node 26 SEA build) was failing its smoke test:

```
Run ./dist/docula version
Error: TypeScript config files require Node.js 22.6.0 or later when using the standalone binary. Please upgrade Node.js or use docula.config.mjs instead.
   at Docula.loadConfigFile (.../sea-entry.cjs:272510:11)
   at async Docula.execute (.../sea-entry.cjs:272335:3)
```

Root cause: `Docula.execute` was calling `loadConfigFile` **before** the `version` short-circuit. The default `sitePath` is `./site`, and the repo has `site/docula.config.ts`, so the SEA binary tried to dynamically import that `.ts` file. Whatever the underlying failure was (TS strip-types, module resolution, etc.), the catch block in `loadConfigFile` swallowed it and threw a stock "Node.js too old" message — even though CI was running on Node 26.

## Changes

- **`src/docula.ts`**: move the `version` short-circuit to sit alongside `help`, *before* `loadConfigFile` runs. The `version` command only needs `package.json` — it doesn't need user config.
- **`src/docula.ts`**: surface the real error in the SEA TS-config catch instead of always claiming the Node version is too old.
- **`test/docula.test.ts`**: refactor `"should load the config and set the options"` to call `parseOptions` directly (it was previously using `version` as a fake no-op command to exercise the parse path).
- **`test/docula.test.ts`**: add a regression test verifying `version` works without loading the site config.

## Test plan

- [x] `pnpm test:ci` — all 656 tests pass (was 655), 100% statement coverage on `docula.ts` maintained
- [x] `pnpm lint:ci` clean
- [ ] `build-binaries` workflow smoke test passes on Node 26 (verified once CI runs)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdY5LJCoE8Q5X4KTBjKyES)_