### PR TITLE
fix(binary): build SEA as ESM to enable dynamic import of file URLs

### DIFF
--- a/tsdown.config.binary.ts
+++ b/tsdown.config.binary.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	entry: ["src/sea-entry.ts"],
-	format: ["cjs"],
+	format: ["esm"],
 	clean: true,
 	deps: {
 		alwaysBundle: [/.*/],


### PR DESCRIPTION
## Summary

Follow-up to #425. With `version` fixed, the `build-binaries` smoke test now reaches its second step (`docula build -s ./test/fixtures/single-page-site`) and fails with:

```
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: file:///.../docula.config.mjs
   at loadBuiltinModuleForEmbedder (node:internal/modules/helpers:165:9)
   at importModuleDynamicallyForEmbedder (node:internal/modules/esm/utils:250:10)
   at Docula.loadConfigFile (.../sea-entry.cjs:272522:83)
   at embedderRunCjs (node:internal/main/embedding:93:10)
```

Root cause: Node 26's SEA embedder routes dynamic `import()` calls in **CJS-mode** bundles (`embedderRunCjs`) through the builtin-module loader, which throws for any `file://` URL. The fixture has a `docula.config.mjs` that `loadConfigFile` tries to import dynamically.

## Change

Switch the SEA bundle from `format: ["cjs"]` to `format: ["esm"]` in `tsdown.config.binary.ts`. tsdown propagates this to `seaConfig.mainFormat = "module"`, so the SEA runs via Node's `embedderRunEsmRoot` path — which uses the standard ESM loader and resolves file URLs correctly.

The source is already ESM (`"type": "module"`, uses `import.meta.url`, no CJS constructs), so no source changes are needed.

## Test plan

- [x] `pnpm test:ci` — all 656 tests pass
- [x] `pnpm lint:ci` clean
- [ ] `build-binaries` workflow smoke test passes (verifies on dispatch)

I can't reproduce this locally (need Node ≥ 25.7.0 for tsdown's `exe`; local is Node 22), so the actual SEA verification will happen in CI when the workflow is dispatched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdY5LJCoE8Q5X4KTBjKyES)_