### PR TITLE
docs: add Aikido security audit report badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![npm](https://img.shields.io/npm/dm/docula)](https://npmjs.com/package/docula)
 [![npm](https://img.shields.io/npm/v/docula)](https://npmjs.com/package/docula)
 
-<a href="https://app.aikido.dev/audit-report/external/lZAT2DfBsT11ZQfpYwClKi6s/request" target="_blank">
-    <img src="https://app.aikido.dev/assets/badges/full-light-theme.svg" alt="Aikido Security Audit Report" height="40" />    
+<a href="https://app.aikido.dev/audit-report/external/lZAT2DfBsT11ZQfpYwClKi6s/request" target="_blank" rel="noopener noreferrer">
+    <img src="https://app.aikido.dev/assets/badges/full-light-theme.svg" alt="Aikido Security Audit Report" height="40" />
 </a>
 
 # Features

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 [![npm](https://img.shields.io/npm/dm/docula)](https://npmjs.com/package/docula)
 [![npm](https://img.shields.io/npm/v/docula)](https://npmjs.com/package/docula)
 
+<a href="https://app.aikido.dev/audit-report/external/lZAT2DfBsT11ZQfpYwClKi6s/request" target="_blank">
+    <img src="https://app.aikido.dev/assets/badges/full-light-theme.svg" alt="Aikido Security Audit Report" height="40" />    
+</a>
+
 # Features
 * No configuration required. Just setup the folder structure with a logo, favicon, and css file.
 * Builds a static website that can be hosted anywhere.


### PR DESCRIPTION
## Summary
- Adds an Aikido Security Audit Report badge to the README.md, linking to the public audit report request page.

## Test plan
- [ ] Verify badge renders correctly on the README on GitHub
- [ ] Confirm the link opens the Aikido audit report request page in a new tab


---
_Generated by [Claude Code](https://claude.ai/code/session_0185tPMntiMWNm2N8YobHt3M)_