### PR TITLE
fix(binary): drop githubPath from smoke fixture to skip GH API call

### DIFF
--- a/test/fixtures/single-page-site/docula.config.json
+++ b/test/fixtures/single-page-site/docula.config.json
@@ -1,5 +1,4 @@
 {
-	"githubPath": "jaredwray/docula",
 	"siteTitle": "Docula",
 	"siteDescription": "Beautiful Website for Your Projects",
 	"siteUrl": "https://docula.org"


### PR DESCRIPTION
## Summary

Follow-up to #428. With the JSON-config loader landed, the smoke test now reaches its build step and starts executing — but fails with HTTP 403:

```
Run ./dist/docula version
2.0.0
Error: Fetch failed with status 403
   at async Github.getReleases (.../dist/docula:271301:19)
   at async Github.getData (.../dist/docula:271287:19)
   at async DoculaBuilder.build (.../dist/docula:271836:52)
```

The fixture's `docula.config.json` carried `githubPath: "jaredwray/docula"`, so the build tries to hit `api.github.com/repos/jaredwray/docula/releases`. The `build-binaries` smoke step has no token, so anonymous rate limits / runner-IP ACL return 403.

## Change

Drop `githubPath` from `test/fixtures/single-page-site/docula.config.json`. The smoke test's job is to verify the binary can run a build end-to-end, not to exercise the GitHub integration (which is covered by the regular test suite under `GH_TOKEN`). The sibling `docula.config.mjs` in the same fixture keeps `githubPath` for non-SEA tests.

## Test plan

- [x] `pnpm test:ci` — 657 tests pass
- [ ] `build-binaries` smoke test reaches `test -f ./smoke-dist/index.html` (verifies in CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdY5LJCoE8Q5X4KTBjKyES)_