### PR TITLE
ci(binary): drop macOS x64 build, keep only macos-latest (arm64)

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -20,7 +20,7 @@ jobs:
           - os: macos-latest
             artifact: docula-macos-arm64
             binary: docula
-          - os: macos-13
+          - os: macos-15-intel
             artifact: docula-macos-x64
             binary: docula
           - os: windows-latest

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -20,9 +20,6 @@ jobs:
           - os: macos-latest
             artifact: docula-macos-arm64
             binary: docula
-          - os: macos-15-intel
-            artifact: docula-macos-x64
-            binary: docula
           - os: windows-latest
             artifact: docula-windows-x64
             binary: docula.exe

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ The CI workflow (`.github/workflows/build-binaries.yaml`) builds each platform n
 |---|---|---|
 | Linux x64 | `ubuntu-latest` | `docula-linux-x64` |
 | macOS ARM64 | `macos-latest` | `docula-macos-arm64` |
-| macOS x64 | `macos-13` | `docula-macos-x64` |
 | Windows x64 | `windows-latest` | `docula-windows-x64` |
 
 Binaries are uploaded as build artifacts on every run and attached to GitHub releases automatically.

--- a/site/docs/binary-download.md
+++ b/site/docs/binary-download.md
@@ -17,7 +17,6 @@ Grab the artifact matching your platform from the [latest release](https://githu
 |----------|----------|
 | Linux x64 | `docula-linux-x64` |
 | macOS arm64 (Apple Silicon) | `docula-macos-arm64` |
-| macOS x64 (Intel) | `docula-macos-x64` |
 | Windows x64 | `docula-windows-x64.exe` |
 
 On macOS and Linux, mark the file as executable after downloading:


### PR DESCRIPTION
## Summary

The `build-binaries` workflow's x64 macOS job was stuck `Waiting for a runner to pick up this job...` indefinitely because GitHub fully retired the `macos-13` runner image on **December 8, 2025** ([changelog](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)).

GitHub is also retiring Intel macOS entirely after Fall 2027. Rather than keep chasing rotating Intel runner labels, drop the x64 macOS build and keep just `macos-latest` (arm64). Intel-Mac users can still run docula via npm/Node.

## Changes

- `build-binaries.yaml`: remove the macOS x64 matrix entry; the remaining macOS job is `macos-latest` (arm64).
- `README.md`: drop the macOS x64 row from the binary matrix.
- `site/docs/binary-download.md`: drop the macOS x64 row from the download table.

## Test plan

- [ ] Dispatch `build-binaries` and confirm only three jobs run (Linux x64, macOS arm64, Windows x64), all green.

## Future considerations

If x64 macOS binary support is needed later, options are a self-hosted Intel runner or cross-compiling from arm64 (with code-signing to avoid the Apple Silicon kernel killing unsigned Mach-O binaries on launch).
