### PR TITLE
fix(api): mitigate SSRF in remote OpenAPI spec fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,10 @@
     "colorette": "^2.0.20",
     "ecto": "^4.8.5",
     "hashery": "^2.0.0",
+    "ipaddr.js": "2.2.0",
     "jiti": "^2.7.0",
     "serve-handler": "^6.1.7",
+    "undici": "7.25.0",
     "update-notifier": "^7.3.1",
     "writr": "^6.1.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,12 +32,18 @@ importers:
       hashery:
         specifier: ^2.0.0
         version: 2.0.0
+      ipaddr.js:
+        specifier: 2.2.0
+        version: 2.2.0
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
       serve-handler:
         specifier: ^6.1.7
         version: 6.1.7
+      undici:
+        specifier: 7.25.0
+        version: 7.25.0
       update-notifier:
         specifier: ^7.3.1
         version: 7.3.1
@@ -1539,6 +1545,10 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  ipaddr.js@2.2.0:
+    resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
+    engines: {node: '>= 10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -3765,6 +3775,8 @@ snapshots:
   ini@4.1.1: {}
 
   inline-style-parser@0.2.7: {}
+
+  ipaddr.js@2.2.0: {}
 
   is-alphabetical@2.0.1: {}
 

--- a/src/builder-api.ts
+++ b/src/builder-api.ts
@@ -9,6 +9,7 @@ import {
 	isPathWithinBasePath,
 	isRemoteUrl,
 } from "./builder-utils.js";
+import { safeFetch } from "./safe-fetch.js";
 import type { DoculaData } from "./types.js";
 
 const writrOptions: WritrOptions = {
@@ -176,11 +177,11 @@ async function parseAndRenderSpec(
 		/* v8 ignore next 9 -- @preserve */
 	} else if (isRemoteUrl(specUrl)) {
 		try {
-			const response = await fetch(specUrl);
+			const response = await safeFetch(specUrl);
 			const specContent = await response.text();
 			apiSpec = parseOpenApiSpec(specContent);
 		} catch {
-			// If remote fetch fails, render page without parsed spec
+			// If remote fetch fails (network error, SSRF block, timeout), render page without parsed spec
 		}
 	}
 
@@ -315,11 +316,11 @@ export async function renderApiContent(
 		apiSpec = parseOpenApiSpec(localSpec.content);
 	} else if (firstSpecUrl && isRemoteUrl(firstSpecUrl)) {
 		try {
-			const response = await fetch(firstSpecUrl);
+			const response = await safeFetch(firstSpecUrl);
 			const specContent = await response.text();
 			apiSpec = parseOpenApiSpec(specContent);
 		} catch {
-			// If remote fetch fails, render page without parsed spec
+			// If remote fetch fails (network error, SSRF block, timeout), render page without parsed spec
 		}
 	}
 

--- a/src/safe-fetch.ts
+++ b/src/safe-fetch.ts
@@ -1,0 +1,416 @@
+import { promises as dns } from "node:dns";
+import net from "node:net";
+import ipaddr from "ipaddr.js";
+import { Agent, type Dispatcher, fetch as undiciFetch } from "undici";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_REDIRECTS = 5;
+const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024;
+const MAX_URL_LENGTH = 8192;
+
+const BLOCKED_HOSTNAMES = new Set([
+	"localhost",
+	"ip6-localhost",
+	"ip6-loopback",
+	"localhost.localdomain",
+]);
+
+const BLOCKED_IPV4_RANGES = new Set<string>([
+	"unspecified",
+	"broadcast",
+	"multicast",
+	"linkLocal",
+	"loopback",
+	"carrierGradeNat",
+	"private",
+	"reserved",
+	"as112",
+	"amt",
+]);
+
+const BLOCKED_IPV6_RANGES = new Set<string>([
+	"unspecified",
+	"linkLocal",
+	"multicast",
+	"loopback",
+	"uniqueLocal",
+	"discard",
+	"rfc6145",
+	"rfc6052",
+	"teredo",
+	"benchmarking",
+	"amt",
+	"as112v6",
+	"reserved",
+]);
+
+export class SsrfBlockedError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "SsrfBlockedError";
+	}
+}
+
+/**
+ * Returns true if `ip` is NOT publicly routable.
+ *
+ * IPv4-mapped (`::ffff:a.b.c.d`), 6to4 (`2002:hh:hh::/16`), and the deprecated
+ * IPv4-compatible (`::a.b.c.d`) IPv6 forms all unwrap to an embedded IPv4
+ * address and are re-validated against the IPv4 rules. Writing a private IPv4
+ * in any of these IPv6 spellings — including the hex form `::ffff:7f00:1` —
+ * therefore does not bypass the IPv4 deny-list.
+ *
+ * Failure-closed: malformed input is treated as private.
+ */
+export function isPrivateIp(ip: string): boolean {
+	if (!ipaddr.isValid(ip)) return true;
+
+	const parsed = ipaddr.parse(ip);
+
+	if (parsed.kind() === "ipv4") {
+		return BLOCKED_IPV4_RANGES.has(parsed.range());
+	}
+
+	const v6 = parsed as ipaddr.IPv6;
+	const range = v6.range();
+
+	if (range === "ipv4Mapped") {
+		return isPrivateIp(v6.toIPv4Address().toString());
+	}
+
+	if (range === "6to4") {
+		const parts = v6.parts;
+		const a = (parts[1] ?? 0) >> 8;
+		const b = (parts[1] ?? 0) & 0xff;
+		const c = (parts[2] ?? 0) >> 8;
+		const d = (parts[2] ?? 0) & 0xff;
+		return isPrivateIp(`${a}.${b}.${c}.${d}`);
+	}
+
+	if (range !== "unicast") {
+		return BLOCKED_IPV6_RANGES.has(range);
+	}
+
+	// IPv4-compatible (::a.b.c.d): first 96 bits zero, last 32 bits the v4.
+	// ipaddr.js classifies these as "unicast" so we unwrap and re-validate.
+	// ::1 lands under "loopback" above, so we never see it here.
+	const parts = v6.parts;
+	if (
+		parts[0] === 0 &&
+		parts[1] === 0 &&
+		parts[2] === 0 &&
+		parts[3] === 0 &&
+		parts[4] === 0 &&
+		parts[5] === 0 &&
+		!(parts[6] === 0 && parts[7] === 0)
+	) {
+		const a = (parts[6] ?? 0) >> 8;
+		const b = (parts[6] ?? 0) & 0xff;
+		const c = (parts[7] ?? 0) >> 8;
+		const d = (parts[7] ?? 0) & 0xff;
+		return isPrivateIp(`${a}.${b}.${c}.${d}`);
+	}
+
+	return false;
+}
+
+export type ResolvedAddress = { address: string; family: 4 | 6 };
+
+export type DnsLookupAllFn = (
+	hostname: string,
+	options: { all: true; verbatim?: boolean },
+) => Promise<Array<{ address: string; family: number }>>;
+
+export type AssertPublicOptions = {
+	lookup?: DnsLookupAllFn;
+};
+
+/**
+ * Validates `url` and, for hostname-based URLs, resolves and validates every
+ * returned IP. Throws SsrfBlockedError if the URL is unparseable, uses a
+ * non-http(s) scheme, embeds credentials, targets a blocked hostname like
+ * `localhost`, or resolves to any non-publicly-routable IP. Returns the
+ * parsed URL and the validated addresses so the caller can pin them at
+ * connect time and close the DNS-rebinding TOCTOU window.
+ */
+export async function resolveAndValidate(
+	url: string,
+	options: AssertPublicOptions = {},
+): Promise<{ urlObj: URL; resolved: ResolvedAddress[] }> {
+	if (url.length > MAX_URL_LENGTH) {
+		throw new SsrfBlockedError(
+			`URL exceeds ${MAX_URL_LENGTH} characters (got ${url.length})`,
+		);
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		throw new SsrfBlockedError(`Invalid URL: ${url}`);
+	}
+
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		throw new SsrfBlockedError(
+			`Only http(s) URLs are allowed (got ${parsed.protocol})`,
+		);
+	}
+
+	if (parsed.username || parsed.password) {
+		throw new SsrfBlockedError(
+			"Refusing to fetch URL with embedded credentials",
+		);
+	}
+
+	const rawHostname = parsed.hostname;
+	/* v8 ignore next 3 -- @preserve */
+	if (!rawHostname) {
+		throw new SsrfBlockedError("URL has no hostname");
+	}
+
+	const hostname =
+		rawHostname.startsWith("[") && rawHostname.endsWith("]")
+			? rawHostname.slice(1, -1)
+			: rawHostname;
+	const lowerHost = hostname.toLowerCase();
+	if (
+		BLOCKED_HOSTNAMES.has(lowerHost) ||
+		lowerHost.endsWith(".localhost") ||
+		lowerHost.endsWith(".localhost.localdomain")
+	) {
+		throw new SsrfBlockedError(`Refusing to fetch from ${hostname}`);
+	}
+
+	if (net.isIP(hostname)) {
+		if (isPrivateIp(hostname)) {
+			throw new SsrfBlockedError(
+				`Refusing to fetch from non-public IP ${hostname}`,
+			);
+		}
+		return {
+			urlObj: parsed,
+			resolved: [
+				{
+					address: hostname,
+					family: net.isIPv6(hostname) ? 6 : 4,
+				},
+			],
+		};
+	}
+
+	const lookupFn = (options.lookup ?? dns.lookup) as DnsLookupAllFn;
+	let addresses: Array<{ address: string; family: number }>;
+	try {
+		addresses = await lookupFn(hostname, { all: true, verbatim: true });
+	} catch (error) {
+		throw new SsrfBlockedError(
+			`DNS lookup for ${hostname} failed: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+
+	if (addresses.length === 0) {
+		throw new SsrfBlockedError(
+			`DNS lookup for ${hostname} returned no addresses`,
+		);
+	}
+
+	for (const { address } of addresses) {
+		if (isPrivateIp(address)) {
+			throw new SsrfBlockedError(
+				`Refusing to fetch from ${hostname} — resolves to non-public IP ${address}`,
+			);
+		}
+	}
+
+	return {
+		urlObj: parsed,
+		resolved: addresses.map((a) => ({
+			address: a.address,
+			family: (a.family === 6 ? 6 : 4) as 4 | 6,
+		})),
+	};
+}
+
+export type SafeFetchOptions = {
+	timeoutMs?: number;
+	maxRedirects?: number;
+	maxBodyBytes?: number;
+	lookup?: DnsLookupAllFn;
+	fetchImpl?: typeof undiciFetch;
+};
+
+/**
+ * fetch wrapper hardened against SSRF:
+ *  - Scheme allow-list (http/https), no embedded credentials, no localhost.
+ *  - The resolved IP is pinned to undici's TCP connect via a custom Agent
+ *    `lookup`, so fetch does not re-resolve the hostname. This closes the
+ *    DNS-rebinding TOCTOU window between validation and connect. TLS SNI
+ *    and certificate validation still use the original hostname because
+ *    undici's connector passes `host: hostname` to `tls.connect` regardless
+ *    of what `lookup` returns; if that internal contract changes in a future
+ *    undici release, this wrapper's TLS-hostname guarantee will need to be
+ *    re-checked.
+ *  - Redirects are followed manually; each target is re-validated and the
+ *    new connect is re-pinned. The previous hop's body is cancelled before
+ *    moving on so the connection is released instead of being held open.
+ *  - `timeoutMs` bounds the total wall-clock budget — the AbortController
+ *    survives until the returned body is fully consumed (or errors), so a
+ *    slow-drip body cannot bypass the deadline.
+ *  - `maxBodyBytes` caps the response body up-front via `content-length`
+ *    (when it parses cleanly as a decimal integer) and during streaming.
+ *  - URLs over `MAX_URL_LENGTH` are rejected before parsing.
+ *  - Per-hop Agents are `destroy()`ed (not gracefully `close()`d) on error
+ *    or after the body is consumed, so a malicious server cannot leak
+ *    sockets by holding a redirected body open.
+ */
+export async function safeFetch(
+	url: string,
+	options: SafeFetchOptions = {},
+): Promise<Response> {
+	const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+	const fetchImpl = options.fetchImpl ?? undiciFetch;
+	const lookup = options.lookup;
+
+	const totalController = new AbortController();
+	const totalTimer = setTimeout(() => totalController.abort(), timeoutMs);
+	const dispatchers: Dispatcher[] = [];
+
+	let cleaned = false;
+	const cleanup = () => {
+		if (cleaned) return;
+		cleaned = true;
+		clearTimeout(totalTimer);
+		for (const d of dispatchers) {
+			d.destroy().catch(() => {});
+		}
+	};
+
+	let currentUrl = url;
+	try {
+		for (let hop = 0; hop <= maxRedirects; hop++) {
+			const { resolved } = await resolveAndValidate(currentUrl, { lookup });
+
+			const dispatcher = new Agent({
+				connect: {
+					/* v8 ignore next 6 -- only invoked by real undici fetch -- @preserve */
+					lookup: (_hostname, _opts, callback) => {
+						(callback as (err: Error | null, addrs: ResolvedAddress[]) => void)(
+							null,
+							resolved,
+						);
+					},
+				},
+			});
+			dispatchers.push(dispatcher);
+
+			const response = (await fetchImpl(currentUrl, {
+				dispatcher,
+				redirect: "manual",
+				signal: totalController.signal,
+			})) as unknown as Response;
+
+			if (response.status >= 300 && response.status < 400) {
+				const location = response.headers.get("location");
+				if (location) {
+					await response.body?.cancel().catch(() => {});
+					let nextUrl: string;
+					try {
+						nextUrl = new URL(location, currentUrl).toString();
+					} catch {
+						throw new SsrfBlockedError(
+							`Invalid redirect Location header (${location}) from ${currentUrl}`,
+						);
+					}
+					currentUrl = nextUrl;
+					continue;
+				}
+				return capResponseBody(response, maxBodyBytes, cleanup);
+			}
+
+			return capResponseBody(response, maxBodyBytes, cleanup);
+		}
+
+		throw new SsrfBlockedError(
+			`Too many redirects (>${maxRedirects}) starting at ${url}`,
+		);
+	} catch (error) {
+		cleanup();
+		throw error;
+	}
+}
+
+function capResponseBody(
+	response: Response,
+	maxBytes: number,
+	onDone: () => void,
+): Response {
+	const contentLength = response.headers.get("content-length");
+	if (contentLength && /^\d+$/.test(contentLength)) {
+		const n = Number.parseInt(contentLength, 10);
+		if (n > maxBytes) {
+			onDone();
+			throw new SsrfBlockedError(
+				`Response body exceeds ${maxBytes} bytes (content-length: ${n})`,
+			);
+		}
+	}
+
+	if (!response.body) {
+		onDone();
+		return response;
+	}
+
+	const reader = response.body.getReader();
+	let received = 0;
+	let finalized = false;
+	const finalize = () => {
+		if (finalized) return;
+		finalized = true;
+		onDone();
+	};
+
+	const cappedStream = new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			try {
+				const { value, done } = await reader.read();
+				if (done) {
+					controller.close();
+					finalize();
+					return;
+				}
+				received += value.byteLength;
+				if (received > maxBytes) {
+					controller.error(
+						new SsrfBlockedError(
+							`Response body exceeds ${maxBytes} bytes (streamed)`,
+						),
+					);
+					reader.cancel().catch(() => {});
+					finalize();
+					return;
+				}
+				controller.enqueue(value);
+				/* v8 ignore start -- reader.read() errors propagate; defensive cleanup -- @preserve */
+			} catch (error) {
+				controller.error(error);
+				finalize();
+			}
+			/* v8 ignore stop */
+		},
+		/* v8 ignore next 4 -- only invoked when the consumer cancels the body stream -- @preserve */
+		cancel() {
+			reader.cancel().catch(() => {});
+			finalize();
+		},
+	});
+
+	return new Response(cappedStream, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: response.headers,
+	});
+}

--- a/src/safe-fetch.ts
+++ b/src/safe-fetch.ts
@@ -233,6 +233,43 @@ export async function resolveAndValidate(
 	};
 }
 
+type LookupCallback = (
+	err: NodeJS.ErrnoException | null,
+	addressOrList?: string | ResolvedAddress[],
+	family?: number,
+) => void;
+
+/**
+ * Builds a `net.lookup`-shaped callback that always returns the pre-validated
+ * `resolved` addresses, ignoring the hostname argument. Supports both call
+ * signatures: when `opts.all` is truthy the callback receives the full array;
+ * otherwise (the shape Node uses when `autoSelectFamily` is disabled) the
+ * callback receives a single `address, family` pair.
+ */
+export function pinnedLookup(
+	resolved: ResolvedAddress[],
+): (
+	hostname: string,
+	opts: { all?: boolean },
+	callback: LookupCallback,
+) => void {
+	return (_hostname, opts, callback) => {
+		if (opts.all) {
+			callback(null, resolved);
+			return;
+		}
+		const first = resolved[0];
+		/* v8 ignore next 4 -- resolved is non-empty by construction in safeFetch -- @preserve */
+		if (!first) {
+			callback(
+				new Error("No pinned address available") as NodeJS.ErrnoException,
+			);
+			return;
+		}
+		callback(null, first.address, first.family);
+	};
+}
+
 export type SafeFetchOptions = {
 	timeoutMs?: number;
 	maxRedirects?: number;
@@ -296,13 +333,7 @@ export async function safeFetch(
 
 			const dispatcher = new Agent({
 				connect: {
-					/* v8 ignore next 6 -- only invoked by real undici fetch -- @preserve */
-					lookup: (_hostname, _opts, callback) => {
-						(callback as (err: Error | null, addrs: ResolvedAddress[]) => void)(
-							null,
-							resolved,
-						);
-					},
+					lookup: pinnedLookup(resolved),
 				},
 			});
 			dispatchers.push(dispatcher);
@@ -317,6 +348,8 @@ export async function safeFetch(
 				const location = response.headers.get("location");
 				if (location) {
 					await response.body?.cancel().catch(() => {});
+					dispatcher.destroy().catch(() => {});
+					dispatchers.pop();
 					let nextUrl: string;
 					try {
 						nextUrl = new URL(location, currentUrl).toString();

--- a/test/safe-fetch.test.ts
+++ b/test/safe-fetch.test.ts
@@ -1,0 +1,508 @@
+import { Agent } from "undici";
+import { describe, expect, it, vi } from "vitest";
+import {
+	isPrivateIp,
+	resolveAndValidate,
+	SsrfBlockedError,
+	safeFetch,
+} from "../src/safe-fetch.js";
+
+const publicLookup = vi.fn(async () => [
+	{ address: "93.184.216.34", family: 4 },
+]);
+
+describe("safe-fetch — isPrivateIp (IPv4)", () => {
+	it("blocks RFC1918, loopback, link-local, multicast, broadcast, CGNAT, TEST-NETs", () => {
+		const blocked = [
+			"0.0.0.0",
+			"10.0.0.1",
+			"10.255.255.255",
+			"100.64.0.1",
+			"100.127.255.255",
+			"127.0.0.1",
+			"127.1.2.3",
+			"169.254.169.254",
+			"172.16.0.1",
+			"172.31.255.255",
+			"192.0.0.1",
+			"192.0.2.1",
+			"192.168.1.1",
+			"198.18.0.1",
+			"198.19.255.255",
+			"198.51.100.1",
+			"203.0.113.1",
+			"224.0.0.1",
+			"239.255.255.255",
+			"240.0.0.1",
+			"255.255.255.255",
+		];
+		for (const ip of blocked) {
+			expect(isPrivateIp(ip), `expected ${ip} to be blocked`).toBe(true);
+		}
+	});
+
+	it("allows publicly routable IPv4 addresses", () => {
+		const allowed = [
+			"1.1.1.1",
+			"8.8.8.8",
+			"93.184.216.34",
+			"100.63.255.255",
+			"100.128.0.1",
+			"172.15.255.255",
+			"172.32.0.1",
+			"169.253.255.255",
+		];
+		for (const ip of allowed) {
+			expect(isPrivateIp(ip), `expected ${ip} to be allowed`).toBe(false);
+		}
+	});
+
+	it("blocks malformed input (fail-closed)", () => {
+		expect(isPrivateIp("not-an-ip")).toBe(true);
+		expect(isPrivateIp("256.0.0.1")).toBe(true);
+		expect(isPrivateIp("")).toBe(true);
+	});
+});
+
+describe("safe-fetch — isPrivateIp (IPv6, including v4-wrapping forms)", () => {
+	it("blocks IPv6 loopback, unspecified, ULA, link-local, multicast, NAT64, documentation", () => {
+		const blocked = [
+			"::",
+			"::1",
+			"fc00::1",
+			"fd12:3456:789a::1",
+			"fe80::1",
+			"febf::1",
+			"ff00::1",
+			"ff02::1",
+			"64:ff9b::1.2.3.4",
+			"2001:db8::1",
+		];
+		for (const ip of blocked) {
+			expect(isPrivateIp(ip), `expected ${ip} to be blocked`).toBe(true);
+		}
+	});
+
+	it("blocks IPv4-mapped IPv6 in both dotted-quad and hex form", () => {
+		expect(isPrivateIp("::ffff:127.0.0.1")).toBe(true);
+		expect(isPrivateIp("::ffff:169.254.169.254")).toBe(true);
+		expect(isPrivateIp("::ffff:10.0.0.1")).toBe(true);
+		expect(isPrivateIp("::ffff:7f00:1")).toBe(true);
+		expect(isPrivateIp("::ffff:a9fe:a9fe")).toBe(true);
+		expect(isPrivateIp("::ffff:c0a8:1")).toBe(true);
+	});
+
+	it("blocks IPv4-compatible IPv6 (`::a.b.c.d` / hex equivalents)", () => {
+		expect(isPrivateIp("::7f00:1")).toBe(true);
+		expect(isPrivateIp("::a9fe:a9fe")).toBe(true);
+		expect(isPrivateIp("::a00:1")).toBe(true);
+	});
+
+	it("blocks 6to4 wrapping a private IPv4", () => {
+		expect(isPrivateIp("2002:7f00:1::")).toBe(true);
+		expect(isPrivateIp("2002:a9fe:a9fe::")).toBe(true);
+		expect(isPrivateIp("2002:a00:1::")).toBe(true);
+	});
+
+	it("allows global-unicast IPv6 and v4-wrapping forms pointing at public v4", () => {
+		expect(isPrivateIp("2606:4700:4700::1111")).toBe(false);
+		expect(isPrivateIp("2001:4860:4860::8888")).toBe(false);
+		expect(isPrivateIp("::ffff:8.8.8.8")).toBe(false);
+		expect(isPrivateIp("::ffff:808:808")).toBe(false);
+		expect(isPrivateIp("2002:808:808::")).toBe(false);
+		expect(isPrivateIp("::8.8.8.8")).toBe(false);
+		expect(isPrivateIp("::808:808")).toBe(false);
+	});
+});
+
+describe("safe-fetch — resolveAndValidate", () => {
+	it("accepts a public https URL and returns the resolved addresses", async () => {
+		const { urlObj, resolved } = await resolveAndValidate(
+			"https://example.com/spec.json",
+			{ lookup: publicLookup },
+		);
+		expect(urlObj.hostname).toBe("example.com");
+		expect(resolved).toEqual([{ address: "93.184.216.34", family: 4 }]);
+	});
+
+	it("rejects unparseable URLs", async () => {
+		await expect(
+			resolveAndValidate("not a url", { lookup: publicLookup }),
+		).rejects.toThrow(SsrfBlockedError);
+	});
+
+	it("rejects non-http(s) schemes", async () => {
+		for (const url of [
+			"file:///etc/passwd",
+			"ftp://example.com/x",
+			"gopher://example.com/",
+			"data:text/plain,hello",
+		]) {
+			await expect(
+				resolveAndValidate(url, { lookup: publicLookup }),
+			).rejects.toThrow(SsrfBlockedError);
+		}
+	});
+
+	it("rejects URLs with embedded credentials", async () => {
+		await expect(
+			resolveAndValidate("https://user:pass@example.com/", {
+				lookup: publicLookup,
+			}),
+		).rejects.toThrow(/credentials/);
+		await expect(
+			resolveAndValidate("https://user@example.com/", {
+				lookup: publicLookup,
+			}),
+		).rejects.toThrow(/credentials/);
+	});
+
+	it("rejects localhost, ip6-localhost, *.localhost without DNS", async () => {
+		const lookup = vi.fn();
+		for (const url of [
+			"http://localhost/",
+			"http://LOCALHOST/",
+			"http://api.localhost/",
+			"http://ip6-localhost/",
+			"http://ip6-loopback/",
+			"http://localhost.localdomain/",
+		]) {
+			await expect(resolveAndValidate(url, { lookup })).rejects.toThrow(
+				SsrfBlockedError,
+			);
+		}
+		expect(lookup).not.toHaveBeenCalled();
+	});
+
+	it("rejects literal private IPs (including v6 forms) without DNS", async () => {
+		const lookup = vi.fn();
+		for (const url of [
+			"http://169.254.169.254/latest/meta-data/",
+			"http://[::1]/",
+			"http://[::ffff:7f00:1]/",
+			"http://[::ffff:a9fe:a9fe]/",
+			"http://[2002:a9fe:a9fe::]/",
+		]) {
+			await expect(resolveAndValidate(url, { lookup })).rejects.toThrow(
+				/non-public IP/,
+			);
+		}
+		expect(lookup).not.toHaveBeenCalled();
+	});
+
+	it("accepts a literal public IP without DNS", async () => {
+		const lookup = vi.fn();
+		const { resolved } = await resolveAndValidate("https://1.1.1.1/spec.json", {
+			lookup,
+		});
+		expect(resolved).toEqual([{ address: "1.1.1.1", family: 4 }]);
+		expect(lookup).not.toHaveBeenCalled();
+	});
+
+	it("blocks when any resolved address is private", async () => {
+		const lookup = vi.fn(async () => [
+			{ address: "8.8.8.8", family: 4 },
+			{ address: "127.0.0.1", family: 4 },
+		]);
+		await expect(
+			resolveAndValidate("https://attacker.example.com/", { lookup }),
+		).rejects.toThrow(/non-public IP 127\.0\.0\.1/);
+	});
+
+	it("blocks when DNS lookup fails", async () => {
+		const lookup = vi.fn(async () => {
+			throw new Error("ENOTFOUND");
+		});
+		await expect(
+			resolveAndValidate("https://does-not-exist.invalid/", { lookup }),
+		).rejects.toThrow(/DNS lookup .* failed: ENOTFOUND/);
+	});
+
+	it("blocks when DNS lookup returns no addresses", async () => {
+		const lookup = vi.fn(async () => []);
+		await expect(
+			resolveAndValidate("https://empty.example.com/", { lookup }),
+		).rejects.toThrow(/returned no addresses/);
+	});
+
+	it("rejects URLs longer than the cap before parsing", async () => {
+		const longUrl = `https://example.com/${"a".repeat(8200)}`;
+		await expect(
+			resolveAndValidate(longUrl, { lookup: publicLookup }),
+		).rejects.toThrow(/exceeds 8192 characters/);
+	});
+});
+
+describe("safe-fetch — safeFetch", () => {
+	it("returns a 2xx response when the URL is public", async () => {
+		const fetchImpl = vi.fn(
+			async () => new Response("ok", { status: 200 }),
+		) as unknown as typeof globalThis.fetch;
+		const response = await safeFetch("https://example.com/spec.json", {
+			lookup: publicLookup,
+			fetchImpl: fetchImpl as never,
+		});
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("ok");
+	});
+
+	it("rejects before calling fetch when the URL is blocked", async () => {
+		const fetchImpl = vi.fn() as unknown as typeof globalThis.fetch;
+		await expect(
+			safeFetch("http://169.254.169.254/", { fetchImpl: fetchImpl as never }),
+		).rejects.toThrow(SsrfBlockedError);
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	it("rejects the IPv6 IPv4-mapped hex bypass form", async () => {
+		const fetchImpl = vi.fn() as unknown as typeof globalThis.fetch;
+		await expect(
+			safeFetch("http://[::ffff:a9fe:a9fe]/latest/meta-data/", {
+				fetchImpl: fetchImpl as never,
+			}),
+		).rejects.toThrow(/non-public IP/);
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	it("pins fetch to the validated IPs via an undici Agent (no TOCTOU)", async () => {
+		const lookup = vi.fn(async () => [{ address: "93.184.216.34", family: 4 }]);
+		let observedDispatcher: unknown;
+		const fetchImpl = vi.fn(async (_url, init?: RequestInit) => {
+			observedDispatcher = (init as { dispatcher?: unknown })?.dispatcher;
+			return new Response("ok", { status: 200 });
+		}) as unknown as typeof globalThis.fetch;
+
+		const response = await safeFetch("https://example.com/spec.json", {
+			lookup,
+			fetchImpl: fetchImpl as never,
+		});
+		expect(response.status).toBe(200);
+		expect(lookup).toHaveBeenCalledTimes(1);
+		expect(observedDispatcher).toBeInstanceOf(Agent);
+	});
+
+	it("redirect hop cancels the previous body so the connection is released", async () => {
+		const bodyCancelled = vi.fn();
+		const firstBody = new ReadableStream<Uint8Array>({
+			start() {},
+			cancel: bodyCancelled,
+		});
+		const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://example.com/start") {
+				return new Response(firstBody, {
+					status: 302,
+					headers: { location: "https://example.com/final" },
+				});
+			}
+			return new Response("done", { status: 200 });
+		}) as unknown as typeof globalThis.fetch;
+
+		const response = await safeFetch("https://example.com/start", {
+			lookup: publicLookup,
+			fetchImpl: fetchImpl as never,
+		});
+		expect(response.status).toBe(200);
+		expect(bodyCancelled).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects garbled redirect Location with SsrfBlockedError", async () => {
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(null, {
+					status: 302,
+					headers: { location: "http://exa mple.com/" },
+				}),
+		) as unknown as typeof globalThis.fetch;
+
+		await expect(
+			safeFetch("https://example.com/start", {
+				lookup: publicLookup,
+				fetchImpl: fetchImpl as never,
+			}),
+		).rejects.toThrow(/Invalid redirect Location header/);
+	});
+
+	it("ignores non-decimal content-length and falls back to streaming cap", async () => {
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response("hi", {
+					status: 200,
+					headers: { "content-length": "99999999garbage" },
+				}),
+		) as unknown as typeof globalThis.fetch;
+
+		const response = await safeFetch("https://example.com/ok", {
+			lookup: publicLookup,
+			fetchImpl: fetchImpl as never,
+			maxBodyBytes: 1024,
+		});
+		expect(await response.text()).toBe("hi");
+	});
+
+	it("follows redirects to a public target and revalidates each hop", async () => {
+		const calls: string[] = [];
+		const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			calls.push(url);
+			if (url === "https://example.com/start") {
+				return new Response(null, {
+					status: 302,
+					headers: { location: "https://example.com/final" },
+				});
+			}
+			return new Response("done", { status: 200 });
+		}) as unknown as typeof globalThis.fetch;
+
+		const response = await safeFetch("https://example.com/start", {
+			lookup: publicLookup,
+			fetchImpl: fetchImpl as never,
+		});
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("done");
+		expect(calls).toEqual([
+			"https://example.com/start",
+			"https://example.com/final",
+		]);
+	});
+
+	it("rejects when a redirect points at a private host", async () => {
+		const lookup = vi.fn(async (hostname: string) => {
+			if (hostname === "example.com") {
+				return [{ address: "93.184.216.34", family: 4 }];
+			}
+			return [{ address: "127.0.0.1", family: 4 }];
+		});
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(null, {
+					status: 301,
+					headers: { location: "http://internal.attacker.example/" },
+				}),
+		) as unknown as typeof globalThis.fetch;
+
+		await expect(
+			safeFetch("https://example.com/start", {
+				lookup,
+				fetchImpl: fetchImpl as never,
+			}),
+		).rejects.toThrow(SsrfBlockedError);
+	});
+
+	it("returns the redirect response untouched when location is missing", async () => {
+		const fetchImpl = vi.fn(
+			async () => new Response(null, { status: 302 }),
+		) as unknown as typeof globalThis.fetch;
+		const response = await safeFetch("https://example.com/", {
+			lookup: publicLookup,
+			fetchImpl: fetchImpl as never,
+		});
+		expect(response.status).toBe(302);
+	});
+
+	it("aborts when too many redirects are followed", async () => {
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(null, {
+					status: 302,
+					headers: { location: "https://example.com/loop" },
+				}),
+		) as unknown as typeof globalThis.fetch;
+
+		await expect(
+			safeFetch("https://example.com/loop", {
+				lookup: publicLookup,
+				fetchImpl: fetchImpl as never,
+				maxRedirects: 2,
+			}),
+		).rejects.toThrow(/Too many redirects/);
+	});
+
+	it("aborts the request when the total timeout elapses", async () => {
+		const fetchImpl = vi.fn(async (_input, init?: RequestInit) => {
+			return await new Promise<Response>((_, reject) => {
+				init?.signal?.addEventListener("abort", () => {
+					reject(new Error("aborted"));
+				});
+			});
+		}) as unknown as typeof globalThis.fetch;
+
+		await expect(
+			safeFetch("https://example.com/slow", {
+				lookup: publicLookup,
+				fetchImpl: fetchImpl as never,
+				timeoutMs: 5,
+			}),
+		).rejects.toThrow(/aborted/);
+	});
+
+	it("rejects up-front when content-length exceeds maxBodyBytes", async () => {
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response("x", {
+					status: 200,
+					headers: { "content-length": "10000000" },
+				}),
+		) as unknown as typeof globalThis.fetch;
+
+		await expect(
+			safeFetch("https://example.com/big", {
+				lookup: publicLookup,
+				fetchImpl: fetchImpl as never,
+				maxBodyBytes: 1024,
+			}),
+		).rejects.toThrow(/exceeds 1024 bytes \(content-length/);
+	});
+
+	it("rejects mid-stream when the body exceeds maxBodyBytes without content-length", async () => {
+		const chunk = new Uint8Array(2048);
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(chunk);
+				controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+		const fetchImpl = vi.fn(
+			async () => new Response(stream, { status: 200 }),
+		) as unknown as typeof globalThis.fetch;
+
+		const response = await safeFetch("https://example.com/big", {
+			lookup: publicLookup,
+			fetchImpl: fetchImpl as never,
+			maxBodyBytes: 3000,
+		});
+		await expect(response.text()).rejects.toThrow(
+			/exceeds 3000 bytes \(streamed\)/,
+		);
+	});
+
+	it("returns body unchanged when no Response.body is present", async () => {
+		const fetchImpl = vi.fn(
+			async () => new Response(null, { status: 204 }),
+		) as unknown as typeof globalThis.fetch;
+		const response = await safeFetch("https://example.com/", {
+			lookup: publicLookup,
+			fetchImpl: fetchImpl as never,
+		});
+		expect(response.status).toBe(204);
+	});
+
+	it("URL-length cap rejects oversized redirect targets too", async () => {
+		const huge = `https://example.com/${"a".repeat(8200)}`;
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(null, {
+					status: 302,
+					headers: { location: huge },
+				}),
+		) as unknown as typeof globalThis.fetch;
+
+		await expect(
+			safeFetch("https://example.com/start", {
+				lookup: publicLookup,
+				fetchImpl: fetchImpl as never,
+			}),
+		).rejects.toThrow(/exceeds 8192 characters/);
+	});
+});

--- a/test/safe-fetch.test.ts
+++ b/test/safe-fetch.test.ts
@@ -2,6 +2,7 @@ import { Agent } from "undici";
 import { describe, expect, it, vi } from "vitest";
 import {
 	isPrivateIp,
+	pinnedLookup,
 	resolveAndValidate,
 	SsrfBlockedError,
 	safeFetch,
@@ -112,6 +113,34 @@ describe("safe-fetch — isPrivateIp (IPv6, including v4-wrapping forms)", () =>
 		expect(isPrivateIp("2002:808:808::")).toBe(false);
 		expect(isPrivateIp("::8.8.8.8")).toBe(false);
 		expect(isPrivateIp("::808:808")).toBe(false);
+	});
+});
+
+describe("safe-fetch — pinnedLookup", () => {
+	const resolved = [
+		{ address: "93.184.216.34", family: 4 as const },
+		{ address: "2606:2800:220:1::1", family: 6 as const },
+	];
+
+	it("returns the full array when opts.all is true (autoSelectFamily on)", () => {
+		const lookup = pinnedLookup(resolved);
+		const cb = vi.fn();
+		lookup("example.com", { all: true }, cb);
+		expect(cb).toHaveBeenCalledWith(null, resolved);
+	});
+
+	it("returns a single address+family when opts.all is false (autoSelectFamily off)", () => {
+		const lookup = pinnedLookup(resolved);
+		const cb = vi.fn();
+		lookup("example.com", { all: false }, cb);
+		expect(cb).toHaveBeenCalledWith(null, "93.184.216.34", 4);
+	});
+
+	it("defaults to single-address signature when opts.all is undefined", () => {
+		const lookup = pinnedLookup(resolved);
+		const cb = vi.fn();
+		lookup("example.com", {}, cb);
+		expect(cb).toHaveBeenCalledWith(null, "93.184.216.34", 4);
 	});
 });
 


### PR DESCRIPTION
## Summary

Closes the SSRF surface in `src/builder-api.ts` where `fetch(specUrl)` (lines 179, 318) trusted URLs sourced from `docula.config.json` (`data.openApiSpecs[].url`). A contributor authoring a malicious site config could otherwise point a docula build at internal endpoints — for example `http://169.254.169.254/latest/meta-data/iam/security-credentials/` (AWS IMDS), `http://metadata.google.internal/` (GCP), or an attacker-controlled hostname that returns a private IP via short-TTL DNS rebinding.

Both call-sites now go through a new `safeFetch()` wrapper in `src/safe-fetch.ts`.

## What `safeFetch` enforces

- **Scheme allow-list** (`http:` / `https:` only); no embedded credentials in the URL; explicit hostname denylist for `localhost`, `ip6-localhost`, `ip6-loopback`, `*.localhost`, `localhost.localdomain`.
- **IP classification via `ipaddr.js`**. IPv4-mapped (`::ffff:a.b.c.d` *and* hex form `::ffff:7f00:1`), 6to4 (`2002:hh:hh::`), and the deprecated IPv4-compatible (`::a.b.c.d`) IPv6 forms are unwrapped to the embedded IPv4 and re-validated, so private v4 addresses cannot be smuggled through IPv6 spelling.
- **DNS-rebinding TOCTOU closed**. The validator resolves the hostname once, then pins the resolved addresses to undici's TCP connect via a custom `Agent({ connect: { lookup } })` passed as `dispatcher`. `fetch` does not re-resolve. TLS SNI and certificate validation still bind to the original hostname because undici's connector passes `host: hostname` to `tls.connect`.
- **Redirects followed manually with revalidation**. Each hop's URL is re-checked; the prior hop's body is `cancel()`ed and its `Agent` is `destroy()`ed (graceful `close()` would wait forever for an undrained body) so a malicious 302 can't leak sockets.
- **Total timeout shared across all hops**, kept alive until the response body stream closes — a slow-drip body cannot bypass the deadline.
- **Body size cap** via strict `content-length` pre-check and streaming byte limit (default 10 MB).
- **URL length cap** (8 KiB) to bound redirect-chain growth.

## Threat model addressed

| Attack | Before | After |
|---|---|---|
| `http://169.254.169.254/` (AWS IMDS) | reached | blocked (literal-IP check) |
| `http://[::ffff:a9fe:a9fe]/` (IPv6-hex IMDS) | reached | blocked (ipaddr.js unwrap) |
| `http://[2002:a9fe:a9fe::]/` (6to4 IMDS) | reached | blocked (6to4 unwrap) |
| `http://attacker.test/` resolving to 127.0.0.1 via DNS rebinding mid-request | reached private host | blocked (lookup pinned to validated IP) |
| 302 chain ending at internal host | followed silently | blocked at hop revalidation |
| Slow-drip body past timeout | bypassed timer | aborted (timer survives until body end) |
| 10 GB body | OOMed build | rejected (content-length or streaming cap) |

## Process

This PR was reviewed twice by an agentic code-review primitive (staff-engineer persona). The first pass found 4 🛑 blockers (IPv6 hex bypass, IPv4-compatible bypass, 6to4 bypass, DNS-rebinding TOCTOU) — all four were re-verified closed by the second pass. The second pass's 5 ⚠️ findings (per-hop vs total timeout, two dispatcher-leak paths, lax content-length parsing, redirect URL parse error class) are all addressed in the version submitted here.

## Dependencies

Adds two pinned direct deps. Both were either already in the resolved tree or are tiny:
- `undici@7.25.0` — already transitively present (via `ai` → `@ai-sdk/*`). Same version pinned to avoid drift.
- `ipaddr.js@2.2.0` — no dependencies; battle-tested IP classification (used by `proxy-addr`, express, etc.).

## Test plan

- [x] `pnpm test` passes (713 tests, lint clean)
- [x] `safe-fetch.ts` at 100% line coverage; project coverage 99.9% (up from 99.76%)
- [x] All four IPv6 bypass forms (`::ffff:7f00:1`, `::ffff:a9fe:a9fe`, `::7f00:1`, `2002:7f00:1::`) have explicit blocking tests
- [x] Pin test asserts `dispatcher instanceof Agent`
- [x] Redirect-body-cancel, garbled-Location, non-decimal-content-length all have tests
- [x] Pre-existing `builder-api.test.ts` test that fetches `petstore.swagger.io/v2/swagger.json` continues to pass through `safeFetch`

---
_Generated by [Claude Code](https://claude.ai/code/session_018vXeSQfLFc1mmWVv7RRPHK)_