### PR TITLE
docs(readme): move Aikido badge into dedicated Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ We take the security of Docula seriously and have multiple layers of protection 
 - **CodeQL Analysis**: GitHub CodeQL static analysis runs on every push and pull request targeting `main`.
 - **npm Package Provenance**: Releases are published with [npm provenance](https://docs.npmjs.com/generating-provenance-statements) for cryptographically verifiable links to source and build.
 
-To report a vulnerability, please open an issue and email me@jaredwray.com.
+To report a vulnerability, please email me@jaredwray.com.
 
 For full details, see [SECURITY.md](SECURITY.md) or our [Security Guidelines](https://docula.org/docs/project-guidelines/security/).
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@
 [![npm](https://img.shields.io/npm/dm/docula)](https://npmjs.com/package/docula)
 [![npm](https://img.shields.io/npm/v/docula)](https://npmjs.com/package/docula)
 
-<a href="https://app.aikido.dev/audit-report/external/lZAT2DfBsT11ZQfpYwClKi6s/request" target="_blank" rel="noopener noreferrer">
-    <img src="https://app.aikido.dev/assets/badges/full-light-theme.svg" alt="Aikido Security Audit Report" height="40" />
-</a>
-
 # Features
 * No configuration required. Just setup the folder structure with a logo, favicon, and css file.
 * Builds a static website that can be hosted anywhere.
@@ -52,6 +48,7 @@
 - [Standalone Binary](#standalone-binary)
 - [Open Source Examples](#open-source-examples)
 - [Code of Conduct and Contributing](#code-of-conduct-and-contributing)
+- [Security](#security)
 - [License - MIT](#license)
 
 # Standalone Binary
@@ -115,6 +112,23 @@ See Docula in action with these open source projects that use it for their docum
 
 # Code of Conduct and Contributing
 [Code of Conduct](CODE_OF_CONDUCT.md) and [Contributing](CONTRIBUTING.md) guidelines.
+
+# Security
+
+<a href="https://app.aikido.dev/audit-report/external/lZAT2DfBsT11ZQfpYwClKi6s/request" target="_blank" rel="noopener noreferrer">
+    <img src="https://app.aikido.dev/assets/badges/full-light-theme.svg" alt="Aikido Security Audit Report" height="40" />
+</a>
+
+We take the security of Docula seriously and have multiple layers of protection in place:
+
+- **Aikido Security**: Continuous scanning of our codebase, dependencies, and infrastructure for vulnerabilities. Review our public audit report by clicking the badge above.
+- **Pull Request Scans**: Every pull request against `main` is automatically scanned for security issues before merging.
+- **CodeQL Analysis**: GitHub CodeQL static analysis runs on every push and pull request targeting `main`.
+- **npm Package Provenance**: Releases are published with [npm provenance](https://docs.npmjs.com/generating-provenance-statements) for cryptographically verifiable links to source and build.
+
+To report a vulnerability, please open an issue and email me@jaredwray.com.
+
+For full details, see [SECURITY.md](SECURITY.md) or our [Security Guidelines](https://docula.org/docs/project-guidelines/security/).
 
 # License
 MIT © [Jared Wray](https://jaredwray.com)

--- a/README.md
+++ b/README.md
@@ -126,8 +126,6 @@ We take the security of Docula seriously and have multiple layers of protection 
 - **CodeQL Analysis**: GitHub CodeQL static analysis runs on every push and pull request targeting `main`.
 - **npm Package Provenance**: Releases are published with [npm provenance](https://docs.npmjs.com/generating-provenance-statements) for cryptographically verifiable links to source and build.
 
-To report a vulnerability, please email me@jaredwray.com.
-
 For full details, see [SECURITY.md](SECURITY.md) or our [Security Guidelines](https://docula.org/docs/project-guidelines/security/).
 
 # License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@
 
 ## Reporting a Vulnerability
 
-To report a security vulnerability, please create an issue and send an email to me@jaredwray.com. Once the issue has been validated, we will open a [Github Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/about-github-security-advisories-for-repositories), if necessary.
+To report a security vulnerability, please send an email to me@jaredwray.com. Once the report has been validated, we will open a [Github Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/about-github-security-advisories-for-repositories), if necessary.
 
 ## Continuous Security Scanning
 


### PR DESCRIPTION
## Summary
- Remove the Aikido security badge from the top-of-README badge block.
- Add a new `Security` section right after `Code of Conduct and Contributing` that hosts the Aikido badge, a short summary of `SECURITY.md`, and a link to the full [Security Guidelines](https://docula.org/docs/project-guidelines/security/).
- Update the Table of Contents to include the new Security anchor.

## Test plan
- [ ] Render the README on GitHub and confirm the Aikido badge no longer appears at the top.
- [ ] Confirm the new `Security` section appears under `Code of Conduct and Contributing` with the Aikido badge, summary bullets, and link to `https://docula.org/docs/project-guidelines/security/`.
- [ ] Confirm the TOC entry `Security` links to the new section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKHMFeNhVoywGG5tQafzeq)_