### PR TITLE
root - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Use Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
@@ -38,7 +38,7 @@ jobs:
       run: pnpm test:ci
 
     - name: Code Coverage
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_KEY }}
         files: ./coverage/lcov.info

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
         node-version: ['22', '24', '26']
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:


### PR DESCRIPTION
## Summary
Upgrade GitHub Actions to their latest majors. Final group of the dependency-management **dev phase**.

## Versions
- `actions/checkout` `v6` → `v7` (6 workflows)
- `codecov/codecov-action` `v6` → `v7` (code-coverage workflow)

Already on their latest majors, so unchanged: `actions/setup-node@v6`, `actions/upload-artifact@v7`, `github/codeql-action@v4`, `cloudflare/wrangler-action@v4`.

## Breaking notes
Both are major bumps, but **no breaking impact is expected for this repo**:
- **checkout v7** — main change is an ESM move plus a security restriction that blocks checking out fork-PR code in `pull_request_target` / `workflow_run` workflows. None of docula's workflows use those triggers (verified), so standard `push` / `pull_request` / `release` checkouts are unaffected.
- **codecov-action v7** — no user-facing input/token/behavior changes; `CODECOV_KEY` usage is unchanged.

This PR's own CI exercises `checkout@v7` (tests, codeql, code-coverage) and `codecov-action@v7` (code-coverage), so a green run validates both bumps directly.

## Checks
- [x] All 6 workflow YAML files parse
- [x] Pin style preserved (`@vX` major pins)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SH3sHDijQkCJDHwjU3dhx9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SH3sHDijQkCJDHwjU3dhx9)_