### PR TITLE
root - chore: upgrade ipaddr.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "colorette": "^2.0.20",
     "ecto": "^4.8.7",
     "hashery": "^2.0.0",
-    "ipaddr.js": "2.2.0",
+    "ipaddr.js": "2.4.0",
     "jiti": "^2.7.0",
     "serve-handler": "^6.1.7",
     "undici": "7.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       ipaddr.js:
-        specifier: 2.2.0
-        version: 2.2.0
+        specifier: 2.4.0
+        version: 2.4.0
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
@@ -1557,8 +1557,8 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
-  ipaddr.js@2.2.0:
-    resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
     engines: {node: '>= 10'}
 
   is-alphabetical@2.0.1:
@@ -3812,7 +3812,7 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  ipaddr.js@2.2.0: {}
+  ipaddr.js@2.4.0: {}
 
   is-alphabetical@2.0.1: {}
 


### PR DESCRIPTION
## Summary
Upgrade `ipaddr.js` to its latest `minimumReleaseAge`-gated version. Standalone runtime dependency.

## Versions
- `ipaddr.js` `2.2.0` → `2.4.0` (exact pin preserved — no caret, matching existing style)

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes (695 tests, lint clean, 99.9% line coverage)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SH3sHDijQkCJDHwjU3dhx9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SH3sHDijQkCJDHwjU3dhx9)_