### PR TITLE
root - chore: upgrade undici to 8 (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "author": "Jared Wray <me@jaredwray.com>",
   "engines": {
-    "node": "^22.18.0 || >=24.0.0"
+    "node": "^22.19.0 || >=24.0.0"
   },
   "license": "MIT",
   "scripts": {
@@ -73,7 +73,7 @@
     "ipaddr.js": "2.4.0",
     "jiti": "^2.7.0",
     "serve-handler": "^6.1.7",
-    "undici": "7.25.0",
+    "undici": "8.4.1",
     "update-notifier": "^7.3.1",
     "writr": "^6.1.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^6.1.7
         version: 6.1.7
       undici:
-        specifier: 7.25.0
-        version: 7.25.0
+        specifier: 8.4.1
+        version: 8.4.1
       update-notifier:
         specifier: ^7.3.1
         version: 7.3.1
@@ -2365,6 +2365,10 @@ packages:
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.4.1:
+    resolution: {integrity: sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==}
+    engines: {node: '>=22.19.0'}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -4988,6 +4992,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici@7.25.0: {}
+
+  undici@8.4.1: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 


### PR DESCRIPTION
## Summary
Upgrade `undici` to its latest major. Standalone runtime dependency.

## Versions
- `undici` `7.25.0` → `8.4.1` (exact pin preserved)
- `engines.node` `^22.18.0 || >=24.0.0` → `^22.19.0 || >=24.0.0`

## Breaking notes
- **undici 8 requires Node `>=22.19.0`** (was `>=20.18.1`). docula's `engines` floor for the 22.x line is raised from `22.18.0` → `22.19.0` to stay consistent. `.nvmrc` (24) and CI (22/24/26) already satisfy this.
- undici 8 also enables **HTTP/2 by default** and removes legacy handler wrappers / non-real Blob support. docula's only undici surface is in `src/safe-fetch.ts`: `new Agent({ connect: { lookup } })` (IP-pinning for SSRF protection), `fetch(url, { dispatcher })`, and `Dispatcher.destroy()` — all stable in v8. No code changes were required.

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes (695 tests, lint clean, 99.9% line coverage) — including the `safe-fetch` suite that exercises the undici `Agent`/connect IP-pinning path.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SH3sHDijQkCJDHwjU3dhx9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SH3sHDijQkCJDHwjU3dhx9)_