### PR TITLE
release: v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docula",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Beautiful Website for Your Projects",
   "type": "module",
   "main": "./dist/docula.js",


### PR DESCRIPTION
## Release summary
Minor release: built-in client-side search (⌘K), SSRF hardening, SEA binary config fixes, and a dependency refresh. No public-API breaking changes.

## Packages

| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `docula` | `2.0.0` | `2.1.0` | **minor** | 1 feat, 12 fix, security hardening; no public-API break | 37 |

> Three commits are labeled "(breaking)" but none break docula's public API: **hashery 3** ("no public API changes… No code changes needed"), **undici 8** (only bumps `engines.node` `^22.18.0` → `^22.19.0`, a patch-level minimum within the Node 22 LTS line v2.0.0 already required), and **GitHub Actions** (CI-only). Public exports don't surface undici/hashery/ipaddr types. The new `feat` (⌘K search) sets the minor floor.

---

## docula@2.1.0 — 2026-06-19

Client-side search (⌘K), SSRF hardening, SEA binary fixes, and a dependency refresh.

### Features
- add built-in client-side search (⌘K) to the modern template (a3d3c1c, #445)

  ```jsonc
  // docula.config.json — search is on by default for the modern template;
  // build emits search-index.json and renders the ⌘K / Ctrl-K modal.
  { "enableSearch": true }   // set to false to disable
  ```

### Bug Fixes
- search: robust HTML stripping and Enter-key race in client search (5d4392c, #445)
- search: match lenient script/style end tags; enable search for changelog-only sites (d6ac6e9, #445)
- api: mitigate SSRF in remote OpenAPI spec fetch (1ca11c5, #431)
- safe-fetch: handle both lookup signatures; destroy dispatcher inline on redirect (396618c, #431)
- binary: support docula.config.json; SEA mode loads JSON only (083ed53, #428)
- binary: load .mjs configs without dynamic import() in SEA mode (6fcecc5, #428)
- binary: use createRequire instead of new Function; preserve aliases and scope (10edf8b, #428)
- binary: dedupe require() calls and verify multi-line import handling (1d2e758, #428)
- binary: build SEA as ESM to enable dynamic import of file URLs (eef80ee, #426)
- binary: drop githubPath from smoke fixture to skip GH API call (eabbada, #429)
- binary: skip site config loading for version command (077f4cd, #425)
- release: grant id-token: write for npm OIDC trusted publishing (7ae3269, #424)

### Documentation
- security: add Aikido badge and expand SECURITY.md (6352d7e, #432)
- security: qualify PR scan coverage to main branch (7b55ddd, #432)
- readme: move Aikido badge into dedicated Security section (c2eabf7, #433)
- security: switch vulnerability reports to private email only (4690e60, #433)
- readme: drop vulnerability reporting line from summary (4cb858f, #433)
- add Binary Download page documenting JSON-only SEA config (985cc1f, #428)
- add rel="noopener noreferrer" to Aikido badge link (1f6d5a6, #427)
- add Aikido security audit report badge to README (b5d2d2d, #427)
- re-add Aikido Security Audit badge (1d96c29, #435)

### Internal
- upgrade hashery to 3 — no public API change; Node ≥22.18 already satisfied (dfd72a1, #443)
- upgrade undici to 8; bump engines.node to ^22.19.0 (0f38083, #442)
- upgrade ipaddr.js (1721a15, #441)
- upgrade ecto (5eae9fd, #440)
- upgrade @cacheable/net (9e0e5b0, #439)
- upgrade AI SDK dependencies (211bb19, #438)
- upgrade GitHub Actions — checkout v7, codecov v7 (e8e0d3b, #437)
- upgrade TypeScript and build tooling (b9cc26d, #436)
- upgrade code quality dependencies — biome, vitest (5880166, #435)
- test: rebuild test harness for isolation, determinism, and 100% coverage (bcd6d9c, #444)
- test: harden harness per review — no failure-hiding, no env leaks, safer cloneSite (4f72069, #444)
- test: address Codex review findings on the migrated tests (b78007a, #444)
- ci(binary): drop macOS x64 build, keep only macos-latest arm64 (33619a6, #430)
- ci(binary): replace deprecated macos-13 runner with macos-15-intel (c8308d2, #430)
- ci(release): drop NPM_TOKEN fallback now that OIDC publishes (21607ac, #424)

### Contributors
- @jaredwray (21)

### Full List of Changes
- fix(release): grant id-token: write so pnpm OIDC publish succeeds by @jaredwray in #424
- fix(binary): skip site config loading for `version` command by @jaredwray in #425
- fix(binary): build SEA as ESM to enable dynamic import of file URLs by @jaredwray in #426
- docs: add Aikido security audit report badge to README by @jaredwray in #427
- fix(binary): load .mjs configs without dynamic import() in SEA mode by @jaredwray in #428
- fix(binary): drop githubPath from smoke fixture to skip GH API call by @jaredwray in #429
- ci(binary): drop macOS x64 build, keep only macos-latest (arm64) by @jaredwray in #430
- fix(api): mitigate SSRF in remote OpenAPI spec fetch by @jaredwray in #431
- docs(security): add Aikido badge and expand SECURITY.md by @jaredwray in #432
- docs(readme): move Aikido badge into dedicated Security section by @jaredwray in #433
- root - chore: upgrade code quality dependencies by @jaredwray in #435
- root - chore: upgrade TypeScript and build tooling by @jaredwray in #436
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #437
- root - chore: upgrade AI SDK dependencies by @jaredwray in #438
- root - chore: upgrade @cacheable/net by @jaredwray in #439
- root - chore: upgrade ecto by @jaredwray in #440
- root - chore: upgrade ipaddr.js by @jaredwray in #441
- root - chore: upgrade undici to 8 (breaking) by @jaredwray in #442
- root - chore: upgrade hashery to 3 (breaking) by @jaredwray in #443
- test: rebuild test harness for isolation, determinism, and 100% coverage by @jaredwray in #444
- feat: built-in client-side search (⌘K) for the modern template by @jaredwray in #445

**Full diff:** https://github.com/jaredwray/docula/compare/v2.0.0...v2.1.0

---

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds
- [x] `pnpm test:ci` passes locally — 818 tests, **100% coverage** (statements/branches/functions/lines)
- [x] No uncommitted changes outside the version bump

## Post-merge
Merge, then create a GitHub Release at tag `v2.1.0` (paste the release notes above) — the `release.yaml` workflow publishes to npm via OIDC trusted publishing, and `build-binaries.yaml` attaches the linux/macos/windows binaries to the Release.

> **Note on branch:** this session is pinned to `claude/optimistic-allen-nt6s7p`, so the bump landed there rather than the conventional `release/v2.1.0` branch name. The PR contents (single version-bump commit) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxM8muYF5CwypxLG5L2FbK

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxM8muYF5CwypxLG5L2FbK)_