### PR TITLE
Fix deploy: approve sharp and workerd build scripts for wrangler

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,8 @@ dangerouslyAllowAllBuilds: false
 
 allowBuilds:
   esbuild: true
+  sharp: true
+  workerd: true
 
 minimumReleaseAgeExclude:
   - writr


### PR DESCRIPTION
## Problem

The `deploy-site` workflow fails at the **Publish to Cloudflare Pages** step (`cloudflare/wrangler-action@v4`):

```
dependencies:
+ wrangler 4.100.0

[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: sharp@0.34.5, workerd@1.20260611.1
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
Error: The process '.../pnpm' failed with exit code 1
Error: 🚨 Action failed
```

## Root cause

The wrangler-action doesn't find a local wrangler install, so it runs `pnpm add wrangler@4`. That pulls in `sharp` and `workerd`, both of which have build scripts.

`pnpm-workspace.yaml` sets `strictDepBuilds: true` with `dangerouslyAllowAllBuilds: false`, and the `allowBuilds` allowlist only contained `esbuild`. Under `strictDepBuilds`, any **ignored** (unapproved) build script becomes a **hard error** rather than a warning — so pnpm exits with code 1 even though wrangler itself installed fine. (Note: `esbuild`'s postinstall *did* run in the log, confirming `allowBuilds` is the active mechanism.)

## Fix

Approve the two known-good builds that wrangler requires:

```yaml
allowBuilds:
  esbuild: true
  sharp: true
  workerd: true
```

This resolves the `ERR_PNPM_IGNORED_BUILDS` failure while keeping the repo's security posture intact — builds remain explicitly allowlisted rather than enabling blanket approval (`dangerouslyAllowAllBuilds` stays `false`).

## Validation

- `pnpm-workspace.yaml` parses cleanly and pnpm 11.1.3 accepts the updated config (supply-chain policy verification still passes).
- Config-only change — no `src/` or `test/` code touched, so Biome/Vitest behavior is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzqaQQ3rPk1WB5mnRFMHeZ)_