### PR TITLE
fix(ci): give release binaries unique asset filenames

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -15,14 +15,14 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            artifact: docula-linux-x64
             binary: docula
+            asset: docula-linux-x64
           - os: macos-latest
-            artifact: docula-macos-arm64
             binary: docula
+            asset: docula-macos-arm64
           - os: windows-latest
-            artifact: docula-windows-x64
             binary: docula.exe
+            asset: docula-windows-x64.exe
 
     runs-on: ${{ matrix.os }}
 
@@ -53,12 +53,15 @@ jobs:
       - name: Upload Binary Artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.artifact }}
+          name: ${{ matrix.asset }}
           path: dist/${{ matrix.binary }}
           if-no-files-found: error
 
       - name: Upload to Release
         if: github.event_name == 'release'
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload ${{ github.event.release.tag_name }} dist/${{ matrix.binary }}#${{ matrix.artifact }} --clobber
+        run: |
+          cp "dist/${{ matrix.binary }}" "dist/${{ matrix.asset }}"
+          gh release upload "${{ github.event.release.tag_name }}" "dist/${{ matrix.asset }}" --clobber


### PR DESCRIPTION
## Problem

The `build-binaries` workflow failed on the v2.1.0 release:

```
Run gh release upload v2.1.0 dist/docula#docula-linux-x64 --clobber
HTTP 404: Not Found (https://uploads.github.com/repos/jaredwray/docula/releases/342066385/assets?label=docula-linux-x64&name=docula)
Error: Process completed with exit code 1.
```

### Root cause

The upload used `dist/<binary>#<artifact>`. The `#<artifact>` portion only sets a cosmetic **display label** — it does **not** change the asset's filename (`name`). GitHub keys release assets by `name` (the download URL is `…/download/<tag>/<name>`), and the build always emits a binary literally named `docula` for **both** Linux and macOS (`tsdown` `exe.fileName` is hard-coded to `docula`).

So the Linux and macOS jobs raced to create the **same** asset named `docula` on the same release. The live v2.1.0 assets confirm it:

| Job | asset `name` | `label` | result |
|-----|--------------|---------|--------|
| macOS | `docula` | `docula-macos-arm64` | ✅ uploaded (won the race) |
| Windows | `docula.exe` | `docula-windows-x64` | ✅ uploaded (unique name) |
| Linux | `docula` | `docula-linux-x64` | ❌ **404** — collided with macOS's `docula` |

Same `github.token`, same `contents: write` permission, same release — only the name-colliding job failed, so this is **not** a permissions issue. Even with `--clobber` the two jobs would clobber each other, and both binaries would resolve to the identical download URL `…/download/v2.1.0/docula`.

## Fix

Copy each built binary to a **platform-qualified filename** before upload, so every release asset has a distinct `name` and download URL:

- `docula-linux-x64`
- `docula-macos-arm64`
- `docula-windows-x64.exe`

The same name is reused for the workflow artifact (the redundant `artifact` matrix key is dropped), and the upload step now runs under `bash` on all runners.

```yaml
- name: Upload to Release
  if: github.event_name == 'release'
  shell: bash
  env:
    GH_TOKEN: ${{ github.token }}
  run: |
    cp "dist/${{ matrix.binary }}" "dist/${{ matrix.asset }}"
    gh release upload "${{ github.event.release.tag_name }}" "dist/${{ matrix.asset }}" --clobber
```

The smoke-test step is unchanged (it still runs `dist/<binary>`).

## Repairing the v2.1.0 release

This fix applies to future releases automatically. To backfill v2.1.0, after merge run the workflow manually (it has `workflow_dispatch`) — it will rebuild all three platforms and upload the new uniquely-named assets. The old `docula` (macOS) and `docula.exe` (Windows) assets remain on the release; delete them manually if you want the naming to be consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtngEet9E5xXKvRcrxHjZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtngEet9E5xXKvRcrxHjZs)_