### PR TITLE
fix: pass Cloudflare accountId to wrangler pages deploy

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -40,4 +40,5 @@ jobs:
       uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         command: pages deploy site/dist --project-name=docula --branch=main


### PR DESCRIPTION
## Background

Follow-up to #447. That PR fixed the `pnpm` build-scripts error (`ERR_PNPM_IGNORED_BUILDS` for `sharp`/`workerd`), which let the `deploy-site` workflow get *past* the wrangler install step for the first time. It now reaches the actual deploy command — and fails there:

```
🚀 Running Wrangler Commands
Error: The process '.../pnpm' failed with exit code 1
Error: 🚨 Action failed
```

(`wrangler --version` → `4.100.0` succeeds; the failure is the `pages deploy` invocation.)

## Root cause

The deploy authenticates with **only an API token** and no account ID:

```yaml
with:
  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
  command: pages deploy site/dist --project-name=docula --branch=main
```

When a Cloudflare API token can access more than one account, `wrangler` cannot pick one in non-interactive (CI) mode and aborts with exit 1 (`No account id found, quitting..`). This step was never exercised before because the install always failed first (pre-#447).

## Fix

Pass the account ID, matching [Cloudflare's documented `wrangler-action` Pages setup](https://github.com/cloudflare/wrangler-action):

```yaml
with:
  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
  command: pages deploy site/dist --project-name=docula --branch=main
```

## ⚠️ Action required

This needs a **`CLOUDFLARE_ACCOUNT_ID`** repository secret (Settings → Secrets and variables → Actions). The account ID is on the right-hand sidebar of the Cloudflare dashboard, or via `wrangler whoami`.

If the deploy still fails after adding the secret, the next most likely cause is the **API token's permissions** (it needs **Account → Cloudflare Pages → Edit**) or the **`docula` Pages project not existing** on that account — in which case the wrangler error line just above `Error: The process...` will say so.

## Notes / scope

- I intentionally did **not** wire up the action's `gitHubToken` input. It makes the action create GitHub Deployment records, which requires `deployments: write` permission plus an extra API call — added failure surface on a deploy we're trying to get green. Happy to add it as a follow-up if you want Deployment tracking in the GitHub UI.
- No `wrangler.toml`/`wrangler.jsonc` exists in the repo, so the account ID must come from the action input/secret (this PR) rather than config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzqaQQ3rPk1WB5mnRFMHeZ)_