### PR TITLE
Fix Documentation nav link staying highlighted when embedded under a base path

### DIFF
--- a/templates/modern/includes/scripts.hbs
+++ b/templates/modern/includes/scripts.hbs
@@ -265,23 +265,33 @@
       });
     }
 
-    // Active header nav link highlighting
-    const navLinks = document.querySelectorAll('.header-bottom__item');
-    navLinks.forEach((link) => {
-      const href = link.getAttribute('href');
-      if (currentPath.startsWith(href)) {
-        link.classList.add('header-bottom__item--active');
-      }
-    });
-
-    // Active mobile nav link highlighting
-    const mobileNavLinks = document.querySelectorAll('.mobile-nav__item');
-    mobileNavLinks.forEach((link) => {
-      const href = link.getAttribute('href');
-      if (currentPath.startsWith(href)) {
-        link.classList.add('mobile-nav__item--active');
-      }
-    });
+    // Active nav link highlighting (header + mobile). Highlight only the
+    // single most-specific link: the one whose href is the longest prefix of
+    // the current path. A plain startsWith() check lights up every link whose
+    // href merely prefixes the path, so when the site is embedded under a base
+    // path (e.g. served at /developer with docs at that root) the Documentation
+    // link — whose href is a prefix of every page — would stay highlighted
+    // everywhere. Trailing slashes are normalized so matches stop at a path
+    // boundary, and external/absolute links are skipped.
+    const withTrailingSlash = (p) => (p.endsWith('/') ? p : p + '/');
+    const here = withTrailingSlash(currentPath);
+    const markActiveNav = (selector, activeClass) => {
+      let bestLink = null;
+      let bestLength = -1;
+      document.querySelectorAll(selector).forEach((link) => {
+        const href = link.getAttribute('href');
+        // Only same-origin path links can match the current pathname.
+        if (!href || href.charAt(0) !== '/') return;
+        const base = withTrailingSlash(href);
+        if (here.startsWith(base) && base.length > bestLength) {
+          bestLink = link;
+          bestLength = base.length;
+        }
+      });
+      if (bestLink) bestLink.classList.add(activeClass);
+    };
+    markActiveNav('.header-bottom__item', 'header-bottom__item--active');
+    markActiveNav('.mobile-nav__item', 'mobile-nav__item--active');
 
     // TOC extraction: move the inline TOC into the right sidebar and hide the original
     const tocHeading = document.getElementById('table-of-contents');

--- a/templates/modern/includes/scripts.hbs
+++ b/templates/modern/includes/scripts.hbs
@@ -266,23 +266,24 @@
     }
 
     // Active nav link highlighting (header + mobile). Highlight only the
-    // single most-specific link: the one whose href is the longest prefix of
+    // single most-specific link: the one whose path is the longest prefix of
     // the current path. A plain startsWith() check lights up every link whose
-    // href merely prefixes the path, so when the site is embedded under a base
-    // path (e.g. served at /developer with docs at that root) the Documentation
-    // link — whose href is a prefix of every page — would stay highlighted
-    // everywhere. Trailing slashes are normalized so matches stop at a path
-    // boundary, and external/absolute links are skipped.
+    // path merely prefixes the current one, so when the site is embedded under
+    // a base path (e.g. served at /developer with docs at that root) the
+    // Documentation link — whose path is a prefix of every page — would stay
+    // highlighted everywhere. Trailing slashes are normalized so matches stop
+    // at a path boundary. We read the anchor's resolved origin/pathname so
+    // absolute, relative, and same-origin hrefs all work, while cross-origin
+    // links and non-anchor items (e.g. the mobile logout button) are skipped.
     const withTrailingSlash = (p) => (p.endsWith('/') ? p : p + '/');
     const here = withTrailingSlash(currentPath);
     const markActiveNav = (selector, activeClass) => {
       let bestLink = null;
       let bestLength = -1;
       document.querySelectorAll(selector).forEach((link) => {
-        const href = link.getAttribute('href');
-        // Only same-origin path links can match the current pathname.
-        if (!href || href.charAt(0) !== '/') return;
-        const base = withTrailingSlash(href);
+        // Only same-origin anchors can match the current pathname.
+        if (!link.href || link.origin !== window.location.origin) return;
+        const base = withTrailingSlash(link.pathname);
         if (here.startsWith(base) && base.length > bestLength) {
           bestLink = link;
           bestLength = base.length;


### PR DESCRIPTION
## Problem

When a docula site (modern template) is embedded inside another app — e.g. a Next.js site — and served under a base path with the docs at that root, the **Documentation** nav link stays highlighted on every page (Changelog, API Reference, etc.), not just the docs pages.

## Root cause

The header/mobile nav highlight logic in `templates/modern/includes/scripts.hbs` used a plain prefix test:

```js
if (currentPath.startsWith(href)) {
  link.classList.add('header-bottom__item--active');
}
```

The Documentation link's href is `{{docsUrl}}/` = `buildUrlPath(baseUrl, docsPath)` + `/`. When the site is embedded under a base path (e.g. `/developer`) with the docs served at that root (`docsPath` empty), the href becomes `/developer/` — a **prefix of every page** (`/developer/changelog/`, `/developer/api/`, …). So `startsWith` matched it everywhere. The loop also had no "most specific wins" rule, so more than one tab could light up at once.

## Fix

Highlight only the **single most-specific** link — the one whose href is the *longest* matching prefix of the current path. Trailing slashes are normalized so matches stop at a path-segment boundary, and external/absolute links are skipped. This is applied to both the desktop header nav and the mobile nav.

Result by example (base `/developer`, docs at root):
- `/developer/` → **Documentation** (only match)
- `/developer/changelog/` → **Changelog** (`/developer/changelog/` is longer than `/developer/`)
- `/developer/api/` → **API Reference**
- `/developer/some-doc/` → **Documentation**

The standalone (non-embedded) default deployment continues to behave exactly as before.

## Testing

- `pnpm build` — succeeds
- `pnpm test` — lint clean, **818 tests pass**, **100% coverage** maintained

The change is confined to the modern template's client-side script. The classic template highlights nav via exact-match (`element.href === window.location.href`) and is unaffected. Coverage is scoped to `src/**/*.ts`; there is no existing DOM/jsdom harness for template client-side scripts, so no unit test was added (consistent with the rest of the template scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGFwcEoH3zGLRVpg5ASXMq