### PR TITLE
feat: add support for google tag manager environments

### DIFF
--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -33,6 +33,9 @@ export const options: Partial<DoculaOptions> = {
   siteUrl: 'https://your-site.com',
   themeMode: 'light', // or 'dark' — defaults to system preference if omitted
   googleTagManager: 'GTM-XXXXXX', // or 'G-XXXXXXXXXX' for GA4
+  // To target a Google Tag Manager environment, also set:
+  // googleTagManagerAuth: 'abc123',
+  // googleTagManagerEnv: 'env-3',
   homeUrl: '/', // logo links to this URL instead of baseUrl
   baseUrl: '/docs', // host under a subpath
   autoReadme: true, // use project root README.md as the home page
@@ -184,5 +187,7 @@ When both config files exist, Docula loads them in this order (first found wins)
 | `apiPath` | `string` | `'api'` | Output subdirectory and URL segment for API reference pages. |
 | `changelogPath` | `string` | `'changelog'` | Output subdirectory and URL segment for changelog pages. |
 | `googleTagManager` | `string` | - | Google Tag Manager container ID (e.g., `'GTM-XXXXXX'`) or Google Analytics 4 measurement ID (e.g., `'G-XXXXXXXXXX'`). Injects the appropriate tracking script on every page. |
+| `googleTagManagerAuth` | `string` | - | Google Tag Manager environment auth token (`gtm_auth`). Applies to GTM container IDs only; requires `googleTagManagerEnv`. |
+| `googleTagManagerEnv` | `string` | - | Google Tag Manager environment name (`gtm_preview`), e.g., `'env-3'`. Applies to GTM container IDs only; requires `googleTagManagerAuth`. |
 | `autoReadme` | `boolean` | `true` | Automatically use the project root `README.md` as the home page when no `README.md` exists in the site directory. The leading `# Title` heading is stripped from the rendered page to avoid duplicating the site title. Set to `false` to disable this fallback. |
 | `allowedAssets` | `string[]` | *(see [Assets & Public Folder](/docs/assets))* | File extensions to copy from `docs/` and `changelog/` to output |

--- a/src/builder-cache.ts
+++ b/src/builder-cache.ts
@@ -98,6 +98,8 @@ export function hashOptions(hash: Hashery, options: DoculaOptions): string {
 		changelogPath: options.changelogPath,
 		ai: options.ai,
 		googleTagManager: options.googleTagManager,
+		googleTagManagerAuth: options.googleTagManagerAuth,
+		googleTagManagerEnv: options.googleTagManagerEnv,
 	};
 	const optionsHash = hash.toHashSync(JSON.stringify(relevant));
 	const configHash = hashConfigFile(hash, options.sitePath);

--- a/src/builder-utils.ts
+++ b/src/builder-utils.ts
@@ -83,12 +83,12 @@ export function isRemoteUrl(url: string): boolean {
 }
 
 /**
- * Encode a value for use in a Google Tag Manager URL. `encodeURIComponent`
- * leaves single quotes untouched, so escape them too — the params are injected
- * into a single-quoted JavaScript string literal in the GTM template, where a
- * raw quote would break the script.
+ * Encode a value for use in a URL query string. Unlike `encodeURIComponent`,
+ * this also escapes single quotes, so the result is safe to inject into a
+ * single-quoted JavaScript string literal (e.g., inline template scripts)
+ * where a raw quote would break the string.
  */
-function encodeGtmValue(value: string): string {
+function encodeQueryStringValue(value: string): string {
 	return encodeURIComponent(value).replace(/'/g, "%27");
 }
 
@@ -105,7 +105,7 @@ export function buildGtmEnvironmentParams(
 	if (!auth || !env) {
 		return undefined;
 	}
-	return `&gtm_auth=${encodeGtmValue(auth)}&gtm_preview=${encodeGtmValue(
-		env,
-	)}&gtm_cookies_win=x`;
+	return `&gtm_auth=${encodeQueryStringValue(
+		auth,
+	)}&gtm_preview=${encodeQueryStringValue(env)}&gtm_cookies_win=x`;
 }

--- a/src/builder-utils.ts
+++ b/src/builder-utils.ts
@@ -83,6 +83,16 @@ export function isRemoteUrl(url: string): boolean {
 }
 
 /**
+ * Encode a value for use in a Google Tag Manager URL. `encodeURIComponent`
+ * leaves single quotes untouched, so escape them too — the params are injected
+ * into a single-quoted JavaScript string literal in the GTM template, where a
+ * raw quote would break the script.
+ */
+function encodeGtmValue(value: string): string {
+	return encodeURIComponent(value).replace(/'/g, "%27");
+}
+
+/**
  * Build the extra query string appended to Google Tag Manager URLs when
  * targeting a GTM environment. A GTM environment is identified by both an
  * auth token and an environment name, so this returns `undefined` unless
@@ -95,7 +105,7 @@ export function buildGtmEnvironmentParams(
 	if (!auth || !env) {
 		return undefined;
 	}
-	return `&gtm_auth=${encodeURIComponent(auth)}&gtm_preview=${encodeURIComponent(
+	return `&gtm_auth=${encodeGtmValue(auth)}&gtm_preview=${encodeGtmValue(
 		env,
 	)}&gtm_cookies_win=x`;
 }

--- a/src/builder-utils.ts
+++ b/src/builder-utils.ts
@@ -81,3 +81,21 @@ export function summarizeMarkdown(markdown: string, maxLength = 240): string {
 export function isRemoteUrl(url: string): boolean {
 	return /^https?:\/\//i.test(url);
 }
+
+/**
+ * Build the extra query string appended to Google Tag Manager URLs when
+ * targeting a GTM environment. A GTM environment is identified by both an
+ * auth token and an environment name, so this returns `undefined` unless
+ * both are set.
+ */
+export function buildGtmEnvironmentParams(
+	auth?: string,
+	env?: string,
+): string | undefined {
+	if (!auth || !env) {
+		return undefined;
+	}
+	return `&gtm_auth=${encodeURIComponent(auth)}&gtm_preview=${encodeURIComponent(
+		env,
+	)}&gtm_cookies_win=x`;
+}

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -69,7 +69,11 @@ import {
 	resolveJsonLd as _resolveJsonLd,
 	resolveOpenGraphData as _resolveOpenGraphData,
 } from "./builder-seo.js";
-import { buildUrlPath, isRemoteUrl } from "./builder-utils.js";
+import {
+	buildGtmEnvironmentParams,
+	buildUrlPath,
+	isRemoteUrl,
+} from "./builder-utils.js";
 import { DoculaConsole } from "./console.js";
 import {
 	Github,
@@ -247,6 +251,10 @@ export class DoculaBuilder {
 			headerLinks: this.options.headerLinks,
 			googleTagManager: this.options.googleTagManager,
 			isGtag: this.options.googleTagManager?.startsWith("G-") ?? false,
+			googleTagManagerParams: buildGtmEnvironmentParams(
+				this.options.googleTagManagerAuth,
+				this.options.googleTagManagerEnv,
+			),
 			enableLlmsTxt: this.options.enableLlmsTxt,
 			homeUrl: this.options.homeUrl,
 			baseUrl: this.options.baseUrl,

--- a/src/options.ts
+++ b/src/options.ts
@@ -198,6 +198,16 @@ export class DoculaOptions {
 	 */
 	public googleTagManager?: string;
 	/**
+	 * Google Tag Manager environment auth token (gtm_auth). Only applies to
+	 * GTM container IDs; requires `googleTagManagerEnv` to also be set.
+	 */
+	public googleTagManagerAuth?: string;
+	/**
+	 * Google Tag Manager environment name (gtm_preview), e.g., "env-3". Only
+	 * applies to GTM container IDs; requires `googleTagManagerAuth` to also be set.
+	 */
+	public googleTagManagerEnv?: string;
+	/**
 	 * AI-powered metadata enrichment configuration. When set, uses AI to fill
 	 * missing OpenGraph and HTML meta tag fields during the build.
 	 * Requires provider name and API key. Omit to disable AI enrichment.
@@ -385,6 +395,22 @@ export class DoculaOptions {
 			/^G[A-Z]*-[A-Z0-9]+$/i.test(options.googleTagManager)
 		) {
 			this.googleTagManager = options.googleTagManager;
+		}
+
+		if (
+			options.googleTagManagerAuth !== undefined &&
+			typeof options.googleTagManagerAuth === "string" &&
+			options.googleTagManagerAuth.length > 0
+		) {
+			this.googleTagManagerAuth = options.googleTagManagerAuth;
+		}
+
+		if (
+			options.googleTagManagerEnv !== undefined &&
+			typeof options.googleTagManagerEnv === "string" &&
+			options.googleTagManagerEnv.length > 0
+		) {
+			this.googleTagManagerEnv = options.googleTagManagerEnv;
 		}
 
 		if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,7 @@ export type DoculaData = {
 	}>;
 	googleTagManager?: string;
 	isGtag?: boolean;
+	googleTagManagerParams?: string;
 	enableLlmsTxt?: boolean;
 	enableSearch?: boolean;
 	hasFeed?: boolean;

--- a/templates/classic/includes/body-scripts.hbs
+++ b/templates/classic/includes/body-scripts.hbs
@@ -1,7 +1,7 @@
 {{#if googleTagManager}}
 {{#unless isGtag}}
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{googleTagManager}}"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{googleTagManager}}{{{googleTagManagerParams}}}"
 height="0" width="0" style="display:none !important;visibility:hidden !important"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {{/unless}}

--- a/templates/classic/includes/header.hbs
+++ b/templates/classic/includes/header.hbs
@@ -8,7 +8,7 @@
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+'https://www.googletagmanager.com/gtm.js?id='+i+dl+'{{{googleTagManagerParams}}}';f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','{{googleTagManager}}');</script>
 <!-- End Google Tag Manager -->
 {{/if}}

--- a/templates/modern/includes/body-scripts.hbs
+++ b/templates/modern/includes/body-scripts.hbs
@@ -1,7 +1,7 @@
 {{#if googleTagManager}}
 {{#unless isGtag}}
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{googleTagManager}}"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{googleTagManager}}{{{googleTagManagerParams}}}"
 height="0" width="0" style="display:none !important;visibility:hidden !important"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {{/unless}}

--- a/templates/modern/includes/header.hbs
+++ b/templates/modern/includes/header.hbs
@@ -8,7 +8,7 @@
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+'https://www.googletagmanager.com/gtm.js?id='+i+dl+'{{{googleTagManagerParams}}}';f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','{{googleTagManager}}');</script>
 <!-- End Google Tag Manager -->
 {{/if}}

--- a/test/builder-utils.test.ts
+++ b/test/builder-utils.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	buildAbsoluteSiteUrl,
+	buildGtmEnvironmentParams,
 	buildUrlPath,
 	escapeXml,
 	isPathWithinBasePath,
@@ -131,6 +132,33 @@ describe("builder-utils", () => {
 		it("returns false for local paths", () => {
 			expect(isRemoteUrl("/api/spec.json")).toBe(false);
 			expect(isRemoteUrl("./spec.json")).toBe(false);
+		});
+	});
+
+	describe("buildGtmEnvironmentParams", () => {
+		it("returns undefined when neither auth nor env is set", () => {
+			expect(buildGtmEnvironmentParams()).toBeUndefined();
+			expect(buildGtmEnvironmentParams("", "")).toBeUndefined();
+		});
+
+		it("returns undefined when only auth is set", () => {
+			expect(buildGtmEnvironmentParams("abc123")).toBeUndefined();
+		});
+
+		it("returns undefined when only env is set", () => {
+			expect(buildGtmEnvironmentParams(undefined, "env-3")).toBeUndefined();
+		});
+
+		it("builds params when both auth and env are set", () => {
+			expect(buildGtmEnvironmentParams("abc123", "env-3")).toBe(
+				"&gtm_auth=abc123&gtm_preview=env-3&gtm_cookies_win=x",
+			);
+		});
+
+		it("url-encodes auth and env values", () => {
+			expect(buildGtmEnvironmentParams("a b/c", "env 3")).toBe(
+				"&gtm_auth=a%20b%2Fc&gtm_preview=env%203&gtm_cookies_win=x",
+			);
 		});
 	});
 });

--- a/test/builder-utils.test.ts
+++ b/test/builder-utils.test.ts
@@ -160,5 +160,11 @@ describe("builder-utils", () => {
 				"&gtm_auth=a%20b%2Fc&gtm_preview=env%203&gtm_cookies_win=x",
 			);
 		});
+
+		it("encodes single quotes so the JS string literal is not broken", () => {
+			expect(buildGtmEnvironmentParams("a'b", "env'3")).toBe(
+				"&gtm_auth=a%27b&gtm_preview=env%273&gtm_cookies_win=x",
+			);
+		});
 	});
 });

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -2316,6 +2316,37 @@ describe("DoculaBuilder", () => {
 			}
 		});
 
+		it("should render GTM environment params when auth and env are configured", async () => {
+			const options = new DoculaOptions();
+			options.quiet = true;
+			options.template = "modern";
+			options.sitePath = cloneFixture("test/fixtures/multi-page-site");
+			options.output = makeTempDir("build-gtm-env");
+			options.googleTagManager = "GTM-ENV1234";
+			options.googleTagManagerAuth = "abc123";
+			options.googleTagManagerEnv = "env-3";
+			const builder = new DoculaBuilder(options);
+
+			try {
+				await builder.build();
+				const indexHtml = await fs.promises.readFile(
+					`${options.output}/index.html`,
+					"utf8",
+				);
+				expect(indexHtml).toContain(
+					"gtm.js?id='+i+dl+'&gtm_auth=abc123&gtm_preview=env-3&gtm_cookies_win=x'",
+				);
+				expect(indexHtml).toContain(
+					"ns.html?id=GTM-ENV1234&gtm_auth=abc123&gtm_preview=env-3&gtm_cookies_win=x",
+				);
+			} finally {
+				await fs.promises.rm(options.output, {
+					recursive: true,
+					force: true,
+				});
+			}
+		});
+
 		it("should render GA4 gtag.js scripts when G- prefix is used", async () => {
 			const options = new DoculaOptions();
 			options.quiet = true;

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -351,6 +351,42 @@ describe("DoculaOptions", () => {
 			expect(freshOptions.googleTagManager).toBeUndefined();
 		});
 
+		it("should have googleTagManagerAuth and googleTagManagerEnv undefined by default", () => {
+			const freshOptions = new DoculaOptions();
+			expect(freshOptions.googleTagManagerAuth).toBeUndefined();
+			expect(freshOptions.googleTagManagerEnv).toBeUndefined();
+		});
+
+		it("should parse googleTagManagerAuth and googleTagManagerEnv", () => {
+			options.parseOptions({
+				googleTagManager: "GTM-XXXXXX",
+				googleTagManagerAuth: "abc123",
+				googleTagManagerEnv: "env-3",
+			});
+			expect(options.googleTagManager).toEqual("GTM-XXXXXX");
+			expect(options.googleTagManagerAuth).toEqual("abc123");
+			expect(options.googleTagManagerEnv).toEqual("env-3");
+		});
+
+		it("should not set googleTagManagerAuth for non-string values", () => {
+			options.parseOptions({ googleTagManagerAuth: 123 });
+			expect(options.googleTagManagerAuth).toBeUndefined();
+		});
+
+		it("should not set googleTagManagerEnv for non-string values", () => {
+			options.parseOptions({ googleTagManagerEnv: 123 });
+			expect(options.googleTagManagerEnv).toBeUndefined();
+		});
+
+		it("should not set googleTagManagerAuth or googleTagManagerEnv for empty strings", () => {
+			options.parseOptions({
+				googleTagManagerAuth: "",
+				googleTagManagerEnv: "",
+			});
+			expect(options.googleTagManagerAuth).toBeUndefined();
+			expect(options.googleTagManagerEnv).toBeUndefined();
+		});
+
 		it("should parse cookieAuth with loginUrl", () => {
 			options.parseOptions({
 				cookieAuth: { loginUrl: "/login" },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — adds Google Tag Manager environment support to the site config.

**What is the current behavior?**

`googleTagManager` accepts a single container ID (`GTM-XXXXXX`) or GA4 measurement ID (`G-XXXXXXXXXX`) and always injects the `Live` tag. There's no way to point the tag at a specific GTM environment (staging, QA, etc.), which requires the `gtm_auth` and `gtm_preview` parameters from an environment snippet.

**What is the new behavior?**

Two new optional config options let you target a GTM environment:

- `googleTagManagerAuth` → sets `gtm_auth`
- `googleTagManagerEnv` → sets `gtm_preview` (e.g. `env-3`)

```ts
export const options: Partial<DoculaOptions> = {
  googleTagManager: 'GTM-XXXXXX',
  googleTagManagerAuth: 'abc123',
  googleTagManagerEnv: 'env-3',
};
```

When both are set, the generated GTM gtm.js script and the <noscript> ns.html iframe URLs get `&gtm_auth=...&gtm_preview=...&gtm_cookies_win=x` appended (values are URL-encoded). Both are required together since a GTM environment is identified by both an auth token and a preview name. Setting only one is ignored and emits nothing. These options apply to GTM container IDs only, not GA4. Both the modern and classic templates are updated.

**Implementation notes**

- New `buildGtmEnvironmentParams` helper in builder-utils.ts builds the query suffix (returns undefined unless both auth and env are present).
- New fields are included in the build cache hash, so changing  `googleTagManagerAuth` or `googleTagManagerEnv` correctly invalidates cached builds.
- Config options are flat siblings that match the `Partial<DoculaOptions>` type exactly (rather than a nested object with a union type).

**Does this PR introduce a breaking change?**

No. `googleTagManager` behaves exactly as before when the new options are omitted.

**Other information**

Docs updated in `site/docs/configuration.md`. pnpm test passes with 100% coverage (lint, tests, and coverage all green).