### PR TITLE
release: v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docula",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Beautiful Website for Your Projects",
   "type": "module",
   "main": "./dist/docula.js",


### PR DESCRIPTION
## Release summary
Minor release: Google Tag Manager environment support, a nav-highlight fix for base-path embeds, and release/deploy CI fixes. No public-API breaking changes.

## Packages

| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `docula` | `2.1.0` | `2.2.0` | **minor** | 1 feat (GTM environments), 1 template fix, 3 CI/deploy fixes; no public-API break | 8 |

---

## docula@2.2.0 — 2026-07-08

Google Tag Manager environment support, plus a nav-highlight fix and release/deploy CI fixes.

### Features
- add support for Google Tag Manager environments (70a3fac, #451)

  ```ts
  // docula.config.ts — target a specific GTM environment (staging, QA, …)
  export const options: Partial<DoculaOptions> = {
    googleTagManager: 'GTM-XXXXXX',
    googleTagManagerAuth: 'abc123', // → gtm_auth
    googleTagManagerEnv: 'env-3',   // → gtm_preview
  };
  ```

### Bug Fixes
- documentation nav link staying highlighted when embedded under a base path (2952de4, #450)

### Internal
- ci: pass Cloudflare accountId to wrangler pages deploy (310aef9, #449)
- ci: give release binaries unique asset filenames (ea462c7, #448)
- ci: approve sharp and workerd build scripts for wrangler deploy (dc08718, #447)

### Contributors
- @jaredwray (5)
- @Terryda (3)

### Full List of Changes
- Fix deploy: approve sharp and workerd build scripts for wrangler by @jaredwray in #447
- fix(ci): give release binaries unique asset filenames by @jaredwray in #448
- fix: pass Cloudflare accountId to wrangler pages deploy by @jaredwray in #449
- Fix Documentation nav link staying highlighted when embedded under a base path by @jaredwray in #450
- feat: add support for google tag manager environments by @Terryda in #451 (first-time contributor)

**Full diff:** https://github.com/jaredwray/docula/compare/v2.1.0...v2.2.0

---

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds
- [x] `pnpm test:ci` passes locally — 830 tests, **100% coverage** (statements/branches/functions/lines)
- [x] No uncommitted changes outside the version bump

## Post-merge
Merge, then create a GitHub Release at tag `v2.2.0` (paste the release notes above) — the `release.yaml` workflow publishes to npm via OIDC trusted publishing with provenance, and `build-binaries.yaml` attaches the linux/macos/windows binaries to the Release. Both trigger on `release: [released]`.

> **Note on branch:** this session is pinned to `claude/docula-agentic-release-d89p24`, so the bump landed there rather than the conventional `release/v2.2.0` branch name. The PR contents (single version-bump commit) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnuSuNsffkrTWSCTmwirko

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnuSuNsffkrTWSCTmwirko)_