### PR TITLE
root - chore: upgrade ipaddr.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "colorette": "^2.0.20",
     "ecto": "^4.8.7",
     "hashery": "^3.0.1",
-    "ipaddr.js": "2.4.0",
+    "ipaddr.js": "2.5.0",
     "jiti": "^2.7.0",
     "serve-handler": "^6.1.7",
     "undici": "8.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       ipaddr.js:
-        specifier: 2.4.0
-        version: 2.4.0
+        specifier: 2.5.0
+        version: 2.5.0
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
@@ -1610,8 +1610,8 @@ packages:
   inline-style-parser@0.2.9:
     resolution: {integrity: sha512-IttN8BqKLxzUrnTqHI+/hwAJQItBAUjdoHERCDv+oOuX48VP6bzW8+QjOXSfoevzq3YrYAwX1uLHp8TqO9yIeg==}
 
-  ipaddr.js@2.4.0:
-    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+  ipaddr.js@2.5.0:
+    resolution: {integrity: sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==}
     engines: {node: '>= 10'}
 
   is-alphabetical@2.0.1:
@@ -3857,7 +3857,7 @@ snapshots:
 
   inline-style-parser@0.2.9: {}
 
-  ipaddr.js@2.4.0: {}
+  ipaddr.js@2.5.0: {}
 
   is-alphabetical@2.0.1: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — No source changes; the existing suite (831 tests) passes at 100% coverage.

**What kind of change does this PR introduce?**

Chore — standalone runtime dependency upgrade.

## Summary
Upgrade `ipaddr.js` to the latest `minimumReleaseAge`-gated version. Exact pin style is preserved.

## Changes
- upgrade `ipaddr.js` `2.4.0` → `2.5.0`

## Verification
- [x] `pnpm build` passes
- [x] `pnpm test` passes (831 tests, lint clean, 100% coverage)

## Breaking notes
None. Minor bump; used for private-IP classification in `safe-fetch`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9480a9a-b88c-43fc-854b-b42a07fa297c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9480a9a-b88c-43fc-854b-b42a07fa297c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

