### PR TITLE
root - chore: use caret range for ipaddr.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "colorette": "^2.0.20",
     "ecto": "^4.8.7",
     "hashery": "^3.0.1",
-    "ipaddr.js": "2.5.0",
+    "ipaddr.js": "^2.5.0",
     "jiti": "^2.7.0",
     "serve-handler": "^6.1.7",
     "undici": "8.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       ipaddr.js:
-        specifier: 2.5.0
+        specifier: ^2.5.0
         version: 2.5.0
       jiti:
         specifier: ^2.7.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — Specifier-only; the existing suite (831 tests) passes at 100% coverage.

**What kind of change does this PR introduce?**

Chore — align `ipaddr.js` with the caret ranges used by the other runtime dependencies.

## Summary
#459 kept `ipaddr.js` as an exact pin because that was the previous style (`2.4.0`). Switch it to `^2.5.0` so it matches the rest of `dependencies`.

## Changes
- change `ipaddr.js` `2.5.0` → `^2.5.0`

## Verification
- [x] `pnpm build` passes
- [x] `pnpm test` passes (831 tests, lint clean, 100% coverage)

## Breaking notes
None. Resolved version stays 2.5.0.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9480a9a-b88c-43fc-854b-b42a07fa297c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9480a9a-b88c-43fc-854b-b42a07fa297c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

