### PR TITLE
fix: pin undici to patched releases for SOCKS5 TLS bypass

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici@>=8.0.0 <8.9.0: 8.10.0
+  undici@>=7.0.0 <7.29.0: 7.29.0
+
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,12 @@ allowBuilds:
   sharp: true
   workerd: true
 
+# Force every undici copy onto a release that includes the SOCKS5
+# requestTls fix (8.5.0 / 7.28.0) and the later 8.9.0 / 7.29.0 advisories.
+overrides:
+  "undici@>=8.0.0 <8.9.0": "8.10.0"
+  "undici@>=7.0.0 <7.29.0": "7.29.0"
+
 minimumReleaseAgeExclude:
   - writr
   - ecto


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

GitHub Dependabot grouped 18 `undici` advisories on `pnpm-lock.yaml`, including [GHSA-vmh5-mc38-953g](https://github.com/advisories/GHSA-vmh5-mc38-953g) (CVE-2026-9697): `ProxyAgent` silently drops `requestTls` when the proxy URI is SOCKS5, so `ca` / `cert` / `key` / `rejectUnauthorized` / `servername` are ignored and the connection falls back to the default Mozilla trust store.

The direct `undici` dependency is already `^8.10.0` (resolved `8.10.0` via #461). This change adds pnpm overrides so the rest of the tree cannot drift back onto a vulnerable copy:

- `undici@>=8.0.0 <8.9.0` → `8.10.0` (covers the SOCKS5 fix in 8.5.0 and the later 8.9.0 advisory bundle)
- `undici@>=7.0.0 <7.29.0` → `7.29.0` (covers the 7.28.0 SOCKS5 fix and the 7.29.0 advisory bundle)

Transitive `undici@7.29.0` (from `@cacheable/net` and `@ai-sdk/provider-utils`) stays on the patched 7.x line.

## Test plan

- [x] `pnpm install` records the overrides in `pnpm-lock.yaml`
- [x] `pnpm test` — lint clean, 831 tests passed, 100% coverage
- [x] `pnpm why undici` only reports `8.10.0` and `7.29.0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21fc1cc3-74ff-4d74-a1a4-174cbb34630a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21fc1cc3-74ff-4d74-a1a4-174cbb34630a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

