### PR TITLE
root - chore: defense - scaffold security docs

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -1,0 +1,60 @@
+# Defense in Depth
+
+Tracking against https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md.
+
+Profile: npm library · public
+
+## 1. Security docs
+
+- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR pending)
+- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR pending)
+
+## 2. Repository lockdown
+
+- [ ] Lockdown script run; `lockdown-repo.sh --check` passes clean
+- [ ] Pull requests required on the default branch (1 approving review of the latest push; only the repository owner can merge, and they may merge without a review); force pushes and deletion blocked
+- [ ] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`)
+- [ ] Tag ruleset "Tags only by admins" active
+- [ ] Workflow runs from all outside collaborators require approval
+- [ ] Default workflow token read-only; Actions cannot create or approve PRs
+- [ ] Actions allowlist: GitHub-owned + verified + explicit patterns only (`--allowed-actions`)
+- [ ] Secret scanning + push protection enabled *(plan-gated on private repos)*
+- [ ] Private vulnerability reporting enabled *(public repos only)*
+- [ ] Dependabot alerts enabled
+- [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
+- [ ] Recovery codes stored offline in a password manager (manual)
+- [ ] Dev/release VM network egress filtered by a firewall (e.g. PMG) (manual)
+
+## 3. Dependencies (pnpm)
+
+- [x] `packageManager: pnpm@11.x` pinned in `package.json` — verified 2026-08-16 (`pnpm@11.20.0`)
+- [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — verified 2026-08-16 (`pnpm-workspace.yaml`; first-party exclude: `writr`, `ecto`, `hashery`)
+- [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — verified 2026-08-16 (default-deny; reviewed exceptions for `esbuild`, `sharp`, and `workerd`)
+- [x] `blockExoticSubdeps: true` — verified 2026-08-16
+- [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile`
+- [x] Dependency-update tooling opens PRs only — never auto-merge — verified 2026-08-16 (no auto-merge config in-repo; upgrades via reviewed PRs)
+- [x] New direct dependencies get human review; prefer `~` ranges over `^` — verified 2026-08-16 (all changes via PR; existing runtime deps stay on `^`; new runtime deps prefer `~`)
+
+## 4. GitHub Actions
+
+- [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow
+- [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-16
+- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned)
+- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR
+- [ ] `persist-credentials: false` on checkouts that don't push
+- [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-16
+- [x] No npm tokens (or other registry credentials) in Actions secrets — verified 2026-08-16 (no workflow references `NPM_TOKEN` / `NODE_AUTH_TOKEN`; publish uses OIDC provenance)
+
+## 5. npm publishing — npm libraries only
+
+- [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
+- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual)
+- [ ] Drydock connected — staged releases reviewed before promotion (manual)
+- [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
+- [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-16
+
+## 6. Security tooling
+
+- [x] Aikido runs on every build — verified 2026-08-16 (GitHub check "Aikido Security: check code" on PR #462)
+- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release`
+- [x] Socket reviews every PR that changes dependencies — verified 2026-08-16 (GitHub checks "Socket Security: Pull Request Alerts" and "Project Report" on PR #462)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -6,8 +6,8 @@ Profile: npm library · public
 
 ## 1. Security docs
 
-- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR pending)
-- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR pending)
+- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR #464 pending)
+- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #464 pending)
 
 ## 2. Repository lockdown
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,29 +1,27 @@
 # Security Policy
 
-<a href="https://app.aikido.dev/audit-report/external/lZAT2DfBsT11ZQfpYwClKi6s/request" target="_blank" rel="noopener noreferrer">
-    <img src="https://app.aikido.dev/assets/badges/full-light-theme.svg" alt="Aikido Security Audit Report" height="40" />
-</a>
+We take security seriously and work to keep this project up to date. If you discover a security vulnerability, please report it **privately** so we can investigate and ship a fix before the issue becomes public.
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
-To report a security vulnerability, please send an email to me@jaredwray.com. Once the report has been validated, we will open a [Github Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/about-github-security-advisories-for-repositories), if necessary.
+Please use one of the following private channels — **do not open a public issue, pull request, or discussion** for security concerns:
 
-## Continuous Security Scanning
+1. **Preferred:** open a private report via GitHub's [Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) flow on this repository's **Security** tab.
+2. **Email:** send the details to me@jaredwray.com. If the issue is urgent, include `[SECURITY]` in the subject line and we will respond as soon as possible.
 
-We take the security of Docula seriously and have multiple layers of automated scanning in place to detect vulnerabilities as early as possible:
+When reporting, please include as much of the following as you can:
 
-- **Aikido Security**: We use [Aikido](https://www.aikido.dev/) to continuously scan our codebase, dependencies, and infrastructure for vulnerabilities. You can review our public audit report by clicking the badge above.
-- **Pull Request Scans**: Every pull request opened against the `main` branch is automatically scanned for security issues before it can be merged. This ensures that no new code lands in `main` without first being reviewed for known vulnerabilities, insecure dependencies, and common security pitfalls.
-- **CodeQL Analysis**: We run [GitHub CodeQL](https://codeql.github.com/) static analysis on pushes to `main` and on every pull request targeting `main` to identify potential security issues in our source code.
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof-of-concept.
+- The affected version(s) and platform.
+- Any suggested remediation, if you have one.
 
-## npm Package Provenance
+We will acknowledge receipt, work with you on a coordinated disclosure timeline, and credit you in the advisory once a fix is published unless you ask to remain anonymous.
 
-Docula is published to [npmjs.org](https://www.npmjs.com/package/docula) with [npm package provenance](https://docs.npmjs.com/generating-provenance-statements) enabled via GitHub Actions. Provenance statements provide cryptographically verifiable links between published packages and the source code and build process that produced them.
+## How this repository is secured
 
-This means that when you install Docula from npm, you can verify:
+This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md)
+hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
 
-- The exact source repository and commit the package was built from.
-- The GitHub Actions workflow that built and published the package.
-- That the package has not been tampered with between build and publish.
-
-Our release workflow (`.github/workflows/release.yaml`) uses the `--provenance` flag when publishing, and the GitHub Actions runner is granted the `id-token: write` permission required to generate the signed provenance statement. You can verify the provenance of any published version directly on the [Docula npm page](https://www.npmjs.com/package/docula) or via `npm audit signatures`.
+- Every action is pinned to a full commit SHA.
+- Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Scaffold the public `SECURITY.md` reporting policy and add `DEFENSE_IN_DEPTH.md` so the Node.js defense-in-depth catalog can be tracked one item at a time.

## Status update
`DEFENSE_IN_DEPTH.md`: § 1 Security docs → (PR #464 pending)

## Changes
- Replace `SECURITY.md` with private-disclosure reporting plus a live-only “How this repository is secured” summary
- Add `DEFENSE_IN_DEPTH.md` (profile: npm library · public) and reconcile already-true catalog items

## Verification
- [x] Docs-only change; Biome does not lint markdown
- [x] `pnpm test` (831 tests, 100% coverage)

## Reference
defense-in-depth-nodejs § 1

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

