### PR TITLE
root - chore: defense - set contents: read workflow permissions

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -6,10 +6,12 @@ on:
     types: [released]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-binary:
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -8,10 +8,7 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: write
-
-env:
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,6 +18,8 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -6,12 +6,12 @@ on:
     types: [released]
 
 permissions:
-  contents: write
+  contents: read
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+  GITHUB_TOKEN: ${{ github.token }}
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-  
+ 
 jobs:
   setup-build-deploy:
     name: Deploy Website

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,16 +6,14 @@ on:
     types: [released]
 
 permissions:
-  contents: write
-  id-token: write
-
-env:
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+  contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,10 +8,9 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: write
+  contents: read
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
 jobs:

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -37,7 +37,7 @@ Profile: npm library · public
 
 ## 4. GitHub Actions
 
-- [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow
+- [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow (PR pending)
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-16
 - [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned)
 - [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -37,7 +37,7 @@ Profile: npm library · public
 
 ## 4. GitHub Actions
 
-- [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow (PR pending)
+- [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow (PR #466 pending)
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-16
 - [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned)
 - [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -31,7 +31,7 @@ Profile: npm library · public
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — verified 2026-08-16 (`pnpm-workspace.yaml`; first-party exclude: `writr`, `ecto`, `hashery`)
 - [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — verified 2026-08-16 (default-deny; reviewed exceptions for `esbuild`, `sharp`, and `workerd`)
 - [x] `blockExoticSubdeps: true` — verified 2026-08-16
-- [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` (PR #465 pending)
+- [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — PR #465
 - [x] Dependency-update tooling opens PRs only — never auto-merge — verified 2026-08-16 (no auto-merge config in-repo; upgrades via reviewed PRs)
 - [x] New direct dependencies get human review; prefer `~` ranges over `^` — verified 2026-08-16 (all changes via PR; existing runtime deps stay on `^`; new runtime deps prefer `~`)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,5 +23,5 @@ We will acknowledge receipt, work with you on a coordinated disclosure timeline,
 This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md)
 hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
 
-- Every action is pinned to a full commit SHA.
+- Every action is pinned to a full commit SHA. CI workflows default to read-only `contents` permissions.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Default every GitHub Actions workflow to read-only `contents` permissions and drop the long-lived `GH_TOKEN` PAT from CI.

## Status update
`DEFENSE_IN_DEPTH.md`: `permissions: contents: read` on every workflow → (PR #466 pending)
`DEFENSE_IN_DEPTH.md`: Lockfile committed; CI installs with frozen lockfile → PR #465 (reconciled)

## Changes
- `contents: read` (or `permissions: {}` + per-job grants) on all workflows
- `id-token: write` only on the release publish job
- `contents: write` only on `build-binaries` for `gh release upload`
- Stop injecting `secrets.GH_TOKEN`; deploy-site uses `github.token`

## Verification
- [x] Workflow YAML reviewed for required write grants
- [x] `pnpm test` (831 tests, 100% coverage)

## Reference
defense-in-depth-nodejs § 4

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

