### PR TITLE
root - chore: defense - lint workflows with zizmor

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -55,9 +55,11 @@ jobs:
 
       - name: Smoke Test Binary
         shell: bash
+        env:
+          BINARY_NAME: ${{ matrix.binary }}
         run: |
-          ./dist/${{ matrix.binary }} version
-          ./dist/${{ matrix.binary }} build -s ./test/fixtures/single-page-site -o ./smoke-dist
+          ./dist/${BINARY_NAME} version
+          ./dist/${BINARY_NAME} build -s ./test/fixtures/single-page-site -o ./smoke-dist
           test -f ./smoke-dist/index.html
 
       - name: Upload Binary Artifact
@@ -72,6 +74,9 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          BINARY_NAME: ${{ matrix.binary }}
+          ASSET_NAME: ${{ matrix.asset }}
         run: |
-          cp "dist/${{ matrix.binary }}" "dist/${{ matrix.asset }}"
-          gh release upload "${{ github.event.release.tag_name }}" "dist/${{ matrix.asset }}" --clobber
+          cp "dist/${BINARY_NAME}" "dist/${ASSET_NAME}"
+          gh release upload "${TAG_NAME}" "dist/${ASSET_NAME}" --clobber

--- a/.github/workflows/check-workflows.yaml
+++ b/.github/workflows/check-workflows.yaml
@@ -1,0 +1,28 @@
+name: Check Workflows
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write # SARIF upload to code scanning
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Socket Firewall
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          firewall-version: "1.15.0"
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2

--- a/.github/workflows/check-workflows.yaml
+++ b/.github/workflows/check-workflows.yaml
@@ -26,3 +26,6 @@ jobs:
           firewall-version: "1.15.0"
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          # Fork PRs get a read-only GITHUB_TOKEN, so SARIF upload would fail.
+          advanced-security: ${{ !github.event.pull_request.head.repo.fork }}

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -39,8 +39,8 @@ Profile: npm library · public
 
 - [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — PR #466
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-16
-- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned) (PR #468 pending)
-- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR
+- [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned) — PR #468
+- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR (PR #469 pending)
 - [x] `persist-credentials: false` on checkouts that don't push — PR #467
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-16
 - [x] No npm tokens (or other registry credentials) in Actions secrets — verified 2026-08-16 (no workflow references `NPM_TOKEN` / `NODE_AUTH_TOKEN`; publish uses OIDC provenance)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,5 +23,5 @@ We will acknowledge receipt, work with you on a coordinated disclosure timeline,
 This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md)
 hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
 
-- Every action is pinned to a full commit SHA. CI workflows default to read-only `contents` permissions, and checkouts that do not push set `persist-credentials: false`. Socket Firewall wraps package installs.
+- Every action is pinned to a full commit SHA. CI workflows default to read-only `contents` permissions, and checkouts that do not push set `persist-credentials: false`. Socket Firewall wraps package installs; workflows are security-linted with zizmor on every PR.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Add a zizmor workflow-lint job on every PR and move untrusted GitHub interpolations in `build-binaries` into `env` so the linter stays green.

## Status update
`DEFENSE_IN_DEPTH.md`: `.github/workflows/check-workflows.yaml` lints workflows with zizmor → (PR #469 pending)
`DEFENSE_IN_DEPTH.md`: Every job installs Socket Firewall → PR #468 (reconciled)

## Changes
- Add `.github/workflows/check-workflows.yaml` (least privilege, SHA-pinned checkout, Socket Firewall, zizmor)
- Ran `npx actions-up` — pins already current
- Pass `matrix.*` and `github.event.release.tag_name` through `env` in `build-binaries.yaml`

After this lands, re-run lockdown with `--required-checks "build (22),build (24),build (26),zizmor"`.

## Verification
- [x] `npx actions-up` (all actions up to date)
- [x] `pnpm test` (831 tests, 100% coverage)

## Reference
defense-in-depth-nodejs § 4

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

