### PR TITLE
root - chore: defense - stage npm publishes via OIDC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,6 @@ jobs:
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
-        registry-url: "https://registry.npmjs.org"
         package-manager-cache: false
 
     - name: Enable Corepack

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,8 @@ jobs:
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
+        registry-url: "https://registry.npmjs.org"
+        package-manager-cache: false
 
     - name: Enable Corepack
       run: corepack enable
@@ -41,5 +43,15 @@ jobs:
     - name: Testing
       run: pnpm test:ci
 
-    - name: Publish
-      run: pnpm publish --no-git-checks --provenance
+    - name: Pack
+      run: |
+        mkdir -p packed
+        pnpm pack --pack-destination packed
+        ls -la packed
+
+    - name: Ensure npm CLI for staged publishing
+      # zizmor: ignore[adhoc-packages] pin npm 11.19.0 so `npm stage publish` is available
+      run: npm install --global npm@11.19.0
+
+    - name: Stage publish
+      run: npm stage publish packed/*.tgz --access public --provenance

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -40,7 +40,7 @@ Profile: npm library · public
 - [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — PR #466
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-16
 - [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned) — PR #468
-- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR (PR #469 pending)
+- [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #469
 - [x] `persist-credentials: false` on checkouts that don't push — PR #467
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-16
 - [x] No npm tokens (or other registry credentials) in Actions secrets — verified 2026-08-16 (no workflow references `NPM_TOKEN` / `NODE_AUTH_TOKEN`; publish uses OIDC provenance)
@@ -48,7 +48,7 @@ Profile: npm library · public
 ## 5. npm publishing — npm libraries only
 
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual)
+- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual) (PR #470 pending)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-16

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,3 +25,4 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 
 - Every action is pinned to a full commit SHA. CI workflows default to read-only `contents` permissions, and checkouts that do not push set `persist-credentials: false`. Socket Firewall wraps package installs; workflows are security-linted with zizmor on every PR.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build.
+- npm releases are staged via OIDC trusted publishing (`npm stage publish` with provenance). There are no npm tokens in Actions.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Switch the release workflow from live `pnpm publish` to pack + `npm stage publish` so CI can only stage a release.

## Status update
`DEFENSE_IN_DEPTH.md`: Staged publishing: CI runs `npm stage publish` → (PR #470 pending)
`DEFENSE_IN_DEPTH.md`: zizmor workflow lint → PR #469 (reconciled)

## Changes
- Pack the tarball, pin npm 11.19.0, and run `npm stage publish packed/*.tgz --access public --provenance`
- Set `registry-url` and disable package-manager caching on the publish job
- Document staged OIDC publishing in `SECURITY.md`

## Maintainer (manual, not in this PR)
- On npmjs.com, set the GitHub Actions trusted publisher for `docula` / `release.yaml` to **stage-only**
- Connect [Drydock](https://drydock.org) to review staged tarballs
- Require 2FA and disallow tokens on the package

## Verification
- [x] Release workflow no longer runs `pnpm publish`
- [x] `id-token: write` remains only on the publish job
- [x] `pnpm test` (831 tests, 100% coverage)

## Reference
defense-in-depth-nodejs § 5

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

