### PR TITLE
fix: pin liquidjs to 10.27.1 for memoryLimit DoS advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   undici@>=8.0.0 <8.9.0: 8.10.0
   undici@>=7.0.0 <7.29.0: 7.29.0
+  liquidjs@<10.27.1: 10.27.1
 
 importers:
 
@@ -1718,8 +1719,8 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
-  liquidjs@10.27.0:
-    resolution: {integrity: sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==}
+  liquidjs@10.27.1:
+    resolution: {integrity: sha512-ylE+1q2kSef1UxAyxqbyuWM3FRWS1v48JK1Y3CoW3bD6TSNXZh0+GsVnihujEpKyR+Jejx2aRAFfC3AHm9rElg==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -3472,7 +3473,7 @@ snapshots:
       cacheable: 2.5.0
       ejs: 6.0.1
       hookified: 3.0.1
-      liquidjs: 10.27.0
+      liquidjs: 10.27.1
       nunjucks: 3.2.4
       pug: 3.0.4
       writr: 6.1.5(supports-color@7.2.0)
@@ -3932,7 +3933,7 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  liquidjs@10.27.0:
+  liquidjs@10.27.1:
     dependencies:
       commander: 10.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,9 +12,12 @@ allowBuilds:
 
 # Force every undici copy onto a release that includes the SOCKS5
 # requestTls fix (8.5.0 / 7.28.0) and the later 8.9.0 / 7.29.0 advisories.
+# Force liquidjs onto 10.27.1 for CVE-2026-55575 and AIKIDO-2026-127306
+# (array filters that bypass memoryLimit, enabling DoS).
 overrides:
   "undici@>=8.0.0 <8.9.0": "8.10.0"
   "undici@>=7.0.0 <7.29.0": "7.29.0"
+  "liquidjs@<10.27.1": "10.27.1"
 
 minimumReleaseAgeExclude:
   - writr


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aikido reported two `liquidjs` advisories on `pnpm-lock.yaml`:

- [CVE-2026-55575](https://github.com/advisories/GHSA-g357-x5c3-c72p) (High): the `pop` filter clones arrays without charging `memoryLimit`
- [AIKIDO-2026-127306](https://intel.aikido.dev/cve/AIKIDO-2026-127306) (Medium): related array-filter `memoryLimit` bypass

Worst-case impact is denial of service. Both are fixed in `liquidjs` 10.27.1.

`liquidjs` is not a direct dependency; it is pulled in by `ecto@5.0.0` (`^10.27.0`). This change adds a pnpm override so the tree cannot stay on or drift back to a vulnerable copy:

- `liquidjs@<10.27.1` → `10.27.1`

## Test plan

- [x] `pnpm install` records the override and resolves `liquidjs@10.27.1` in `pnpm-lock.yaml`
- [x] `pnpm test` — lint clean, 831 tests passed, 100% coverage
- [x] `pnpm why liquidjs` only reports `10.27.1`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fca5e4e-1e63-4654-9ef6-cfb2499cb2a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fca5e4e-1e63-4654-9ef6-cfb2499cb2a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

