### PR TITLE
root - chore: defense - record repository lockdown

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -23,9 +23,9 @@ Profile: npm library · public
 - [x] Private vulnerability reporting enabled *(public repos only)* — verified 2026-08-16
 - [x] Dependabot alerts enabled — verified 2026-08-16
 - [x] Dependabot rule: auto-dismiss low + medium (manual) — verified 2026-08-16 (maintainer)
-- [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
-- [ ] Recovery codes stored offline in a password manager (manual)
-- [ ] Dev/release VM network egress filtered by a firewall (e.g. PMG) (manual)
+- [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — verified 2026-08-16 (maintainer)
+- [x] Recovery codes stored offline in a password manager (manual) — verified 2026-08-16 (maintainer)
+- [x] Dev/release VM network egress filtered by a firewall (e.g. PMG) (manual) — verified 2026-08-16 (maintainer)
 
 ## 3. Dependencies (pnpm)
 

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -11,18 +11,18 @@ Profile: npm library · public
 
 ## 2. Repository lockdown
 
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #473 pending)
-- [ ] Lockdown script run; `lockdown-repo.sh --check` passes clean
-- [ ] Pull requests required on the default branch (1 approving review of the latest push, including code owners on owned paths; only the repository owner can merge, and they may merge without a review); force pushes and deletion blocked
-- [ ] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`)
-- [ ] Tag ruleset "Tags only by admins" active
-- [ ] Workflow runs from all outside collaborators require approval
-- [ ] Default workflow token read-only; Actions cannot create or approve PRs
-- [ ] Actions allowlist: GitHub-owned + verified + explicit patterns only (`--allowed-actions`)
-- [ ] Secret scanning + push protection enabled *(plan-gated on private repos)*
-- [ ] Private vulnerability reporting enabled *(public repos only)*
-- [ ] Dependabot alerts enabled
-- [ ] Dependabot rule: auto-dismiss low + medium (manual)
+- [x] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names — PR #473
+- [x] Lockdown script run; `lockdown-repo.sh --check` passes clean — verified 2026-08-16 (maintainer apply)
+- [x] Pull requests required on the default branch (1 approving review of the latest push, including code owners on owned paths; only the repository owner can merge, and they may merge without a review); force pushes and deletion blocked — verified 2026-08-16 (ruleset "Pull requests required")
+- [x] Merges blocked unless required status checks pass (`--required-checks "build (22),build (24),build (26),zizmor"`) — verified 2026-08-16
+- [x] Tag ruleset "Tags only by admins" active — verified 2026-08-16
+- [x] Workflow runs from all outside collaborators require approval — verified 2026-08-16
+- [x] Default workflow token read-only; Actions cannot create or approve PRs — verified 2026-08-16
+- [x] Actions allowlist: GitHub-owned + verified + explicit patterns only (`--allowed-actions "codecov/*,cloudflare/*"`; `zizmorcore/*` and `SocketDev/*` always included) — verified 2026-08-16
+- [x] Secret scanning + push protection enabled *(plan-gated on private repos)* — verified 2026-08-16
+- [x] Private vulnerability reporting enabled *(public repos only)* — verified 2026-08-16
+- [x] Dependabot alerts enabled — verified 2026-08-16
+- [x] Dependabot rule: auto-dismiss low + medium (manual) — verified 2026-08-16 (maintainer)
 - [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
 - [ ] Recovery codes stored offline in a password manager (manual)
 - [ ] Dev/release VM network egress filtered by a firewall (e.g. PMG) (manual)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,9 @@ We will acknowledge receipt, work with you on a coordinated disclosure timeline,
 This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md)
 hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
 
-- Every action is pinned to a full commit SHA. CI workflows default to read-only `contents` permissions, and checkouts that do not push set `persist-credentials: false`. Socket Firewall wraps package installs; workflows are security-linted with zizmor on every PR.
-- Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build, and the release workflow's stage-publish job requires a passing Aikido release gate.
+- All changes land through pull requests — direct pushes to `main` are blocked, and merging requires passing status checks.
+- Tags (and therefore releases) can only be created by repository admins.
+- Workflow runs from outside collaborators always require maintainer approval, and only allowlisted GitHub Actions can run.
+- CI runs with read-only permissions; every action is pinned to a full commit SHA; Socket Firewall wraps package installs; workflows are security-linted with zizmor on every PR.
+- Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build, and the release workflow's stage-publish job requires a passing Aikido release gate.
 - npm releases are staged, never published directly: CI authenticates with **stage-only** OIDC trusted publishing (`npm stage publish` with provenance). Drydock reviews the staged artifact; a maintainer promotes with 2FA. The package requires 2FA and disallows tokens.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Record the maintainer `lockdown-repo.sh` apply and remaining § 2 manuals, and list the now-live PR/tag/Actions controls in `SECURITY.md`.

## Status update
`DEFENSE_IN_DEPTH.md`: § 2 GitHub settings + CODEOWNERS → verified 2026-08-16 / PR #473
`DEFENSE_IN_DEPTH.md`: Dependabot auto-dismiss low + medium → verified 2026-08-16 (maintainer)
`DEFENSE_IN_DEPTH.md`: phishing-resistant 2FA, offline recovery codes, VM egress firewall → verified 2026-08-16 (maintainer)
`SECURITY.md`: added live PR-required, admin-only tags, and Actions allowlist bullets

## Changes
- Check off § 2 items the lockdown script set (rulesets, fork-PR approval, read-only workflow token, Actions allowlist, secret scanning, private vulnerability reporting, Dependabot alerts)
- Check off CODEOWNERS as PR #473
- Check off Dependabot auto-dismiss, phishing-resistant 2FA, recovery codes, and VM egress firewall
- Update the public “How this repository is secured” summary

## Verification
- [x] `pnpm test` (831 tests, 100% coverage)
- [x] Confirmed rulesets `"Pull requests required"` and `"Tags only by admins"` are active, with required checks `build (22)`, `build (24)`, `build (26)`, `zizmor`

## Reference
defense-in-depth-nodejs § 2

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

