### PR TITLE
root - chore: defense - wrap CI installs with Socket Firewall

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -49,7 +49,7 @@ jobs:
         run: corepack enable
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: sfw pnpm install --frozen-lockfile
 
       - name: Build Binary
         run: pnpm build:binary

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -48,6 +48,9 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      - name: Prepare pnpm
+        run: corepack prepare
+
       - name: Install Dependencies
         run: sfw pnpm install --frozen-lockfile
 

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -33,7 +33,7 @@ jobs:
       run: corepack enable
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build
       run: pnpm build

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -32,6 +32,9 @@ jobs:
     - name: Enable Corepack
       run: corepack enable
 
+    - name: Prepare pnpm
+      run: corepack prepare
+
     - name: Install Dependencies
       run: sfw pnpm install --frozen-lockfile
 

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -35,6 +35,9 @@ jobs:
     - name: Enable Corepack
       run: corepack enable
 
+    - name: Prepare pnpm
+      run: corepack prepare
+
     - name: Install Dependencies
       run: sfw pnpm install --frozen-lockfile
 

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -36,7 +36,7 @@ jobs:
       run: corepack enable
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build
       run: pnpm build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,9 @@ jobs:
     - name: Enable Corepack
       run: corepack enable
 
+    - name: Prepare pnpm
+      run: corepack prepare
+
     - name: Install Dependencies
       run: sfw pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Aikido CI client
         # zizmor: ignore[adhoc-packages] pinned Aikido CI client for the release gate
-        run: npm install --global @aikidosec/ci-api-client@1.0.17
+        run: sfw npm install --global @aikidosec/ci-api-client@1.0.17
 
       # Fails on new SAST/IaC/secrets findings. The API key comes from Aikido's
       # Continuous Integration settings — it grants no publish authority.
@@ -68,7 +68,7 @@ jobs:
       run: corepack enable
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build
       run: pnpm build
@@ -84,7 +84,7 @@ jobs:
 
     - name: Ensure npm CLI for staged publishing
       # zizmor: ignore[adhoc-packages] pin npm 11.19.0 so `npm stage publish` is available
-      run: npm install --global npm@11.19.0
+      run: sfw npm install --global npm@11.19.0
 
     - name: Stage publish
       run: npm stage publish packed/*.tgz --access public --provenance

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,6 +39,9 @@ jobs:
     - name: Enable Corepack
       run: corepack enable
 
+    - name: Prepare pnpm
+      run: corepack prepare
+
     - name: Install Dependencies
       run: sfw pnpm install --frozen-lockfile
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
       run: corepack enable
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build
       run: pnpm build

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -41,7 +41,7 @@ Profile: npm library · public
 
 - [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — PR #466
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-16
-- [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned) — PR #468
+- [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); package installs run through `sfw` — PR #468 (PR pending)
 - [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #469
 - [x] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning — PR #475
 - [x] `persist-credentials: false` on checkouts that don't push — PR #467

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -41,7 +41,7 @@ Profile: npm library · public
 
 - [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — PR #466
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-16
-- [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); package installs run through `sfw` — PR #468 (PR pending)
+- [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); package installs run through `sfw` — PR #468, PR #476 pending
 - [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #469
 - [x] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning — PR #475
 - [x] `persist-credentials: false` on checkouts that don't push — PR #467


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Wrap every CI `pnpm install` / `npm install` with `sfw` so Socket Firewall Free actually intercepts registry fetches.

## Status update
`DEFENSE_IN_DEPTH.md`: Socket Firewall wraps package installs → (PR #476 pending)
`SocketDev/action@v1.3.2` only installs `sfw` on `PATH` (no shims). Bare `pnpm install` was bypassing the firewall; CI logs showed `no report output detected`.

## Changes
- `sfw pnpm install --frozen-lockfile` in tests, code-coverage, release, deploy-site, and build-binaries
- `sfw npm install --global …` for the Aikido CI client and pinned npm CLI
- `corepack prepare` before the wrapped install so Corepack’s pnpm download is not proxied (Node 26 undici rejects sfw’s proxy: `invalid onError method`)
- Leave `npm stage publish` unwrapped (publish path, not an install)

## Verification
- [x] `pnpm test` (831 tests, 100% coverage)

## Reference
defense-in-depth-nodejs § 4 (Socket Firewall)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

