### PR TITLE
root - chore: defense - bootstrap Aikido Safe Chain in cloud agents

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+	"install": "bash ./scripts/setup-cloud-environment.sh"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "Node.js",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:latest",
+	"postCreateCommand": "bash ./scripts/setup-cloud-environment.sh"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,11 @@ Docula is a documentation/website generator built with TypeScript and Node.js (>
 - `src/` - TypeScript source code
 - `test/` - Test files (Vitest)
 - `template/` - Handlebars templates
+
+## Safe Chain
+
+Package installs in this environment go through Aikido Safe Chain shims. Never bypass them:
+
+- Keep `~/.safe-chain/shims` first on `PATH`.
+- Do not call unshimmed `npm`, `pnpm`, `npx`, or `pnpx`.
+- Do not install packages with `curl | sh` or by pointing at a package manager outside the shim directory.

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -25,7 +25,7 @@ Profile: npm library · public
 - [x] Dependabot rule: auto-dismiss low + medium (manual) — verified 2026-08-16 (maintainer)
 - [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — verified 2026-08-16 (maintainer)
 - [x] Recovery codes stored offline in a password manager (manual) — verified 2026-08-16 (maintainer)
-- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR pending)
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR #478 pending)
 
 ## 3. Dependencies (pnpm)
 

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -13,7 +13,7 @@ Profile: npm library · public
 
 - [x] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names — PR #473
 - [x] Lockdown script run; `lockdown-repo.sh --check` passes clean — verified 2026-08-16 (maintainer apply)
-- [x] Pull requests required on the default branch (0 required approving reviews, last-push approval off, code-owner review of owned paths); force pushes and deletion blocked — verified 2026-08-16 (ruleset "Pull requests required"; Restrict updates off)
+- [x] Pull requests required on the default branch (0 required approving reviews, last-push approval off, code-owner review of owned paths, Restrict updates off; the owner may merge without a review); force pushes and deletion blocked — verified 2026-08-16 (ruleset "Pull requests required")
 - [x] Merges blocked unless required status checks pass (`--required-checks "build (22),build (24),build (26),zizmor"`) — verified 2026-08-16
 - [x] Tag ruleset "Tags only by admins" active — verified 2026-08-16
 - [x] Workflow runs from all outside collaborators require approval — verified 2026-08-16
@@ -25,7 +25,7 @@ Profile: npm library · public
 - [x] Dependabot rule: auto-dismiss low + medium (manual) — verified 2026-08-16 (maintainer)
 - [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — verified 2026-08-16 (maintainer)
 - [x] Recovery codes stored offline in a password manager (manual) — verified 2026-08-16 (maintainer)
-- [x] Dev/release VM network egress filtered by a firewall (e.g. PMG) (manual) — verified 2026-08-16 (maintainer)
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR pending)
 
 ## 3. Dependencies (pnpm)
 
@@ -41,7 +41,7 @@ Profile: npm library · public
 
 - [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — PR #466
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-16
-- [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); package installs run through `sfw` — PR #468, PR #476
+- [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` — PR #468, PR #476
 - [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #469
 - [x] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning — PR #475
 - [x] `persist-credentials: false` on checkouts that don't push — PR #467

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,7 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - All changes land through pull requests — direct pushes to `main` are blocked, and merging requires passing status checks.
 - Tags (and therefore releases) can only be created by repository admins.
 - Workflow runs from outside collaborators always require maintainer approval, and only allowlisted GitHub Actions can run.
-- CI runs with read-only permissions; every action is pinned to a full commit SHA; Socket Firewall wraps package installs; workflows are security-linted with zizmor on every PR.
+- CI runs with read-only permissions; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR.
+- Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build, and the release workflow's stage-publish job requires a passing Aikido release gate.
 - npm releases are staged, never published directly: CI authenticates with **stage-only** OIDC trusted publishing (`npm stage publish` with provenance). Drydock reviews the staged artifact; a maintainer promotes with 2FA. The package requires 2FA and disallows tokens.

--- a/scripts/setup-cloud-environment.sh
+++ b/scripts/setup-cloud-environment.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# setup-cloud-environment.sh — Aikido Safe Chain bootstrap for Codespaces and Cursor Cloud Agents.
+#
+# Fail closed: never install dependencies unless Safe Chain shims are on PATH.
+# Copied into the target repo as scripts/setup-cloud-environment.sh.
+
+set -euo pipefail
+
+export SAFE_CHAIN_VERSION="1.5.15"
+SAFE_CHAIN_INSTALLER_SHA256="de0565e3d6346407a604e84e639e95fea8758748063da2216bbfdca5feda5dd2"
+SAFE_CHAIN_INSTALLER_URL="https://github.com/AikidoSec/safe-chain/releases/download/${SAFE_CHAIN_VERSION}/install-safe-chain.sh"
+SAFE_CHAIN_SHIMS="${HOME}/.safe-chain/shims"
+SAFE_CHAIN_BIN="${HOME}/.safe-chain/bin"
+
+if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+  cd "$git_root"
+fi
+
+if [[ ! -f pnpm-lock.yaml ]]; then
+  echo "error: pnpm-lock.yaml is required; refusing to install without a frozen lockfile" >&2
+  exit 1
+fi
+
+if [[ -f package.json ]] && grep -q '"packageManager"' package.json && command -v corepack >/dev/null; then
+  corepack enable
+fi
+
+if ! command -v pnpm >/dev/null; then
+  echo "error: pnpm is required on PATH before Safe Chain can wrap it" >&2
+  exit 1
+fi
+
+installer=$(mktemp)
+trap 'rm -f "$installer"' EXIT
+
+curl -fsSL "$SAFE_CHAIN_INSTALLER_URL" -o "$installer"
+echo "${SAFE_CHAIN_INSTALLER_SHA256}  ${installer}" | sha256sum -c -
+
+sh "$installer" --ci
+
+export PATH="${SAFE_CHAIN_SHIMS}:${SAFE_CHAIN_BIN}:${PATH}"
+
+persist_shim_path() {
+  local rc="$1"
+  local line="export PATH=\"${SAFE_CHAIN_SHIMS}:${SAFE_CHAIN_BIN}:\$PATH\""
+  if [[ -f "$rc" ]] && grep -Fq ".safe-chain/shims" "$rc"; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$rc")"
+  printf '\n# Aikido Safe Chain shims\n%s\n' "$line" >> "$rc"
+}
+
+persist_shim_path "${HOME}/.profile"
+persist_shim_path "${HOME}/.bashrc"
+persist_shim_path "${HOME}/.zshrc"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  printf '%s\n' "$SAFE_CHAIN_SHIMS" >> "$GITHUB_PATH"
+  printf '%s\n' "$SAFE_CHAIN_BIN" >> "$GITHUB_PATH"
+fi
+
+pnpm safe-chain-verify
+pnpm install --frozen-lockfile

--- a/scripts/setup-cloud-environment.sh
+++ b/scripts/setup-cloud-environment.sh
@@ -22,7 +22,8 @@ if [[ ! -f pnpm-lock.yaml ]]; then
 fi
 
 if [[ -f package.json ]] && grep -q '"packageManager"' package.json && command -v corepack >/dev/null; then
-  corepack enable
+  # javascript-node owns Node's bin dir as root; enable may need sudo (EACCES).
+  corepack enable || sudo corepack enable
 fi
 
 if ! command -v pnpm >/dev/null; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bootstrap Aikido Safe Chain for Codespaces and Cursor Cloud Agents so package installs in those environments go through pinned `--ci` shims and a frozen lockfile.

## Status update
`DEFENSE_IN_DEPTH.md`: Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain → (PR #478 pending)
Dropped leftover catalog line: Dev/release VM network egress filtered by a firewall (e.g. PMG)

## Changes
- Add `scripts/setup-cloud-environment.sh` (Safe Chain 1.5.15, installer SHA-256 verified)
- Add `.devcontainer/devcontainer.json` and `.cursor/environment.json` that run the script
- Append the Safe Chain section to `AGENTS.md`
- List the live control in `SECURITY.md`

## Verification
- [x] `bash ./scripts/setup-cloud-environment.sh` (installer checksum OK; `pnpm safe-chain-verify`; frozen lockfile install)
- [x] `pnpm test` (831 tests, 100% coverage)

## Reference
defense-in-depth-nodejs § 2 (Safe Chain on Codespaces and Cursor Cloud Agents)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fece15ff-027b-4d46-bde9-0d002f9a9ffa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

