### PR TITLE
Add standalone binary validation harness

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -60,11 +60,8 @@ jobs:
       - name: Smoke Test Binary
         shell: bash
         env:
-          BINARY_NAME: ${{ matrix.binary }}
-        run: |
-          ./dist/${BINARY_NAME} version
-          ./dist/${BINARY_NAME} build -s ./test/fixtures/single-page-site -o ./smoke-dist
-          test -f ./smoke-dist/index.html
+          DOCULA_BINARY: ./dist/${{ matrix.binary }}
+        run: pnpm test:binary
 
       - name: Upload Binary Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Docula is a documentation/website generator built with TypeScript and Node.js (>
 - `pnpm install` - Install dependencies
 - `pnpm build` - Build the project
 - `pnpm test` - Run linter and tests with coverage
+- `pnpm test:binary` - Smoke-test a standalone binary (`dist/docula` or `DOCULA_BINARY`)
 
 **Use pnpm, not npm.**
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,20 @@ This produces a platform-specific binary at `dist/docula` (or `dist/docula.exe` 
 
 ## Testing the Binary
 
-After building, test it locally:
+After building, run the binary harness. It checks `version`, `help`, a JSON-config site build, that TypeScript configs are rejected, `download variables`, and `init`:
+
+```bash
+pnpm test:binary
+```
+
+Or point it at a specific binary:
+
+```bash
+pnpm test:binary -- ./dist/docula
+DOCULA_BINARY=./dist/docula.exe pnpm test:binary
+```
+
+You can also exercise the binary directly:
 
 ```bash
 # Show help

--- a/biome.json
+++ b/biome.json
@@ -10,6 +10,7 @@
 		"includes": [
 			"src/**/*",
 			"test/**/*.ts",
+			"scripts/test-binary.ts",
 			"!src/init.ts",
 			"!src/embedded-templates.ts"
 		]

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint:ci": "biome check --error-on-warnings",
     "test": "pnpm lint && vitest run --coverage",
     "test:ci": "pnpm lint:ci && vitest run --coverage",
+    "test:binary": "tsx scripts/test-binary.ts",
     "test:e2e": "pnpm build && playwright test",
     "docula:help": "pnpm build && node bin/docula.js help",
     "generate-init-file": "tsx scripts/generate-init-file.ts",

--- a/scripts/test-binary.ts
+++ b/scripts/test-binary.ts
@@ -1,0 +1,505 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+import doculaPkg from "../package.json" with { type: "json" };
+
+export const SMOKE_SITE_TITLE = "Binary Smoke";
+export const DEFAULT_COMMAND_TIMEOUT_MS = 60_000;
+
+export type CommandResult = {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+};
+
+export type RunCommand = (
+	binaryPath: string,
+	args: string[],
+	options?: { timeoutMs?: number },
+) => Promise<CommandResult>;
+
+export type HarnessLogger = {
+	log: (message: string) => void;
+	error: (message: string) => void;
+};
+
+export type HarnessOptions = {
+	binaryPath: string;
+	expectedVersion?: string;
+	runCommand?: RunCommand;
+	logger?: HarnessLogger;
+	platform?: string;
+	mkdtemp?: (prefix: string) => string;
+	rm?: (dir: string) => void;
+};
+
+export type CheckResult = {
+	name: string;
+	passed: boolean;
+	detail?: string;
+};
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: needed to strip ANSI escape codes
+const ansiRegex = /\u001B\[[0-9;]*m/g;
+
+export function stripAnsi(value: string): string {
+	return value.replace(ansiRegex, "");
+}
+
+export function defaultBinaryName(platform = process.platform): string {
+	return platform === "win32" ? "docula.exe" : "docula";
+}
+
+export function resolveBinaryPath(
+	argv: string[] = [],
+	env: NodeJS.ProcessEnv = process.env,
+	platform = process.platform,
+	cwd = process.cwd(),
+): string {
+	const fromArgv = argv.find(
+		(argument) => argument !== "--" && argument !== "",
+	);
+	const candidate =
+		fromArgv ??
+		env.DOCULA_BINARY ??
+		path.join("dist", defaultBinaryName(platform));
+	return path.isAbsolute(candidate) ? candidate : path.resolve(cwd, candidate);
+}
+
+export function combinedOutput(result: CommandResult): string {
+	return `${result.stdout}\n${result.stderr}`;
+}
+
+export async function runBinaryCommand(
+	binaryPath: string,
+	args: string[],
+	options: { timeoutMs?: number } = {},
+): Promise<CommandResult> {
+	const timeoutMs = options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+
+	return new Promise((resolve, reject) => {
+		const child = spawn(binaryPath, args, {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+
+		const timer = setTimeout(() => {
+			child.kill("SIGTERM");
+			if (!settled) {
+				settled = true;
+				reject(
+					new Error(
+						`Timed out after ${timeoutMs}ms: ${binaryPath} ${args.join(" ")}`,
+					),
+				);
+			}
+		}, timeoutMs);
+
+		child.stdout.on("data", (chunk: Buffer | string) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on("data", (chunk: Buffer | string) => {
+			stderr += chunk.toString();
+		});
+		child.on("error", (error) => {
+			clearTimeout(timer);
+			if (!settled) {
+				settled = true;
+				reject(error);
+			}
+		});
+		child.on("close", (code) => {
+			clearTimeout(timer);
+			if (!settled) {
+				settled = true;
+				resolve({
+					exitCode: code ?? 1,
+					stdout,
+					stderr,
+				});
+			}
+		});
+	});
+}
+
+export function writeSmokeSite(dir: string): void {
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, "docula.config.json"),
+		`${JSON.stringify(
+			{
+				siteTitle: SMOKE_SITE_TITLE,
+				siteDescription: "Standalone binary smoke test",
+				siteUrl: "https://example.com",
+			},
+			null,
+			"\t",
+		)}\n`,
+	);
+	fs.writeFileSync(
+		path.join(dir, "README.md"),
+		"# Binary Smoke\n\nHello from the binary harness.\n",
+	);
+}
+
+export function writeTypescriptOnlySite(dir: string): void {
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, "docula.config.ts"),
+		'export const options = { siteTitle: "TypeScript Only" };\n',
+	);
+	fs.writeFileSync(path.join(dir, "README.md"), "# TypeScript Only\n");
+}
+
+function ensureExecutable(binaryPath: string, platform: string): void {
+	if (platform === "win32") {
+		return;
+	}
+
+	const stats = fs.statSync(binaryPath);
+	const executable = (stats.mode & 0o111) !== 0;
+	if (!executable) {
+		fs.chmodSync(binaryPath, stats.mode | 0o111);
+	}
+}
+
+async function checkVersion(
+	binaryPath: string,
+	expectedVersion: string,
+	runCommand: RunCommand,
+): Promise<CheckResult> {
+	const result = await runCommand(binaryPath, ["version"]);
+	const version = stripAnsi(result.stdout).trim();
+	if (result.exitCode !== 0) {
+		return {
+			name: "version",
+			passed: false,
+			detail: `exited ${result.exitCode}: ${combinedOutput(result).trim()}`,
+		};
+	}
+
+	if (version !== expectedVersion) {
+		return {
+			name: "version",
+			passed: false,
+			detail: `expected "${expectedVersion}", got "${version}"`,
+		};
+	}
+
+	return { name: "version", passed: true, detail: version };
+}
+
+async function checkHelp(
+	binaryPath: string,
+	runCommand: RunCommand,
+): Promise<CheckResult> {
+	const result = await runCommand(binaryPath, ["help"]);
+	const output = stripAnsi(combinedOutput(result));
+	if (result.exitCode !== 0) {
+		return {
+			name: "help",
+			passed: false,
+			detail: `exited ${result.exitCode}: ${output.trim()}`,
+		};
+	}
+
+	if (!output.includes("Usage:") || !output.includes("build")) {
+		return {
+			name: "help",
+			passed: false,
+			detail: "help output did not include Usage or build",
+		};
+	}
+
+	return { name: "help", passed: true };
+}
+
+async function checkBuild(
+	binaryPath: string,
+	workDir: string,
+	runCommand: RunCommand,
+): Promise<CheckResult> {
+	const siteDir = path.join(workDir, "smoke-site");
+	const outputDir = path.join(workDir, "smoke-dist");
+	writeSmokeSite(siteDir);
+
+	const result = await runCommand(binaryPath, [
+		"build",
+		"-s",
+		siteDir,
+		"-o",
+		outputDir,
+	]);
+	if (result.exitCode !== 0) {
+		return {
+			name: "build",
+			passed: false,
+			detail: `exited ${result.exitCode}: ${combinedOutput(result).trim()}`,
+		};
+	}
+
+	const indexPath = path.join(outputDir, "index.html");
+	if (!fs.existsSync(indexPath)) {
+		return {
+			name: "build",
+			passed: false,
+			detail: `missing ${indexPath}`,
+		};
+	}
+
+	const html = fs.readFileSync(indexPath, "utf8");
+	if (!html.includes(SMOKE_SITE_TITLE)) {
+		return {
+			name: "build",
+			passed: false,
+			detail: `index.html did not contain "${SMOKE_SITE_TITLE}"`,
+		};
+	}
+
+	const requiredFiles = ["robots.txt", "sitemap.xml"];
+	const missing = requiredFiles.filter(
+		(fileName) => !fs.existsSync(path.join(outputDir, fileName)),
+	);
+	if (missing.length > 0) {
+		return {
+			name: "build",
+			passed: false,
+			detail: `missing generated files: ${missing.join(", ")}`,
+		};
+	}
+
+	return { name: "build", passed: true, detail: outputDir };
+}
+
+async function checkTypescriptConfigRejected(
+	binaryPath: string,
+	workDir: string,
+	runCommand: RunCommand,
+): Promise<CheckResult> {
+	const siteDir = path.join(workDir, "ts-only-site");
+	const outputDir = path.join(workDir, "ts-only-dist");
+	writeTypescriptOnlySite(siteDir);
+
+	const result = await runCommand(binaryPath, [
+		"build",
+		"-s",
+		siteDir,
+		"-o",
+		outputDir,
+	]);
+	const output = stripAnsi(combinedOutput(result));
+	if (result.exitCode === 0) {
+		return {
+			name: "json-only config",
+			passed: false,
+			detail:
+				"TypeScript config was accepted; standalone binaries must reject it",
+		};
+	}
+
+	if (!output.includes("docula.config.json")) {
+		return {
+			name: "json-only config",
+			passed: false,
+			detail: `expected a docula.config.json error, got: ${output.trim()}`,
+		};
+	}
+
+	return { name: "json-only config", passed: true };
+}
+
+async function checkDownloadVariables(
+	binaryPath: string,
+	workDir: string,
+	runCommand: RunCommand,
+): Promise<CheckResult> {
+	const siteDir = path.join(workDir, "download-site");
+	fs.mkdirSync(siteDir, { recursive: true });
+
+	const result = await runCommand(binaryPath, [
+		"download",
+		"variables",
+		"-s",
+		siteDir,
+	]);
+	if (result.exitCode !== 0) {
+		return {
+			name: "download variables",
+			passed: false,
+			detail: `exited ${result.exitCode}: ${combinedOutput(result).trim()}`,
+		};
+	}
+
+	const variablesPath = path.join(siteDir, "variables.css");
+	if (!fs.existsSync(variablesPath)) {
+		return {
+			name: "download variables",
+			passed: false,
+			detail: `missing ${variablesPath}`,
+		};
+	}
+
+	return { name: "download variables", passed: true };
+}
+
+async function checkInit(
+	binaryPath: string,
+	workDir: string,
+	runCommand: RunCommand,
+): Promise<CheckResult> {
+	const siteDir = path.join(workDir, "init-site");
+
+	const result = await runCommand(binaryPath, [
+		"init",
+		"--javascript",
+		"-s",
+		siteDir,
+	]);
+	if (result.exitCode !== 0) {
+		return {
+			name: "init",
+			passed: false,
+			detail: `exited ${result.exitCode}: ${combinedOutput(result).trim()}`,
+		};
+	}
+
+	const requiredFiles = ["docula.config.mjs", "logo.png", "favicon.ico"];
+	const missing = requiredFiles.filter(
+		(fileName) => !fs.existsSync(path.join(siteDir, fileName)),
+	);
+	if (missing.length > 0) {
+		return {
+			name: "init",
+			passed: false,
+			detail: `missing init files: ${missing.join(", ")}`,
+		};
+	}
+
+	return { name: "init", passed: true };
+}
+
+export async function runBinaryHarness(
+	options: HarnessOptions,
+): Promise<{ passed: boolean; results: CheckResult[] }> {
+	const logger = options.logger ?? {
+		log: (message) => {
+			console.log(message);
+		},
+		error: (message) => {
+			console.error(message);
+		},
+	};
+	const runCommand = options.runCommand ?? runBinaryCommand;
+	const expectedVersion = options.expectedVersion ?? doculaPkg.version;
+	const platform = options.platform ?? process.platform;
+	const mkdtemp =
+		options.mkdtemp ??
+		((prefix) => fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+	const rm =
+		options.rm ??
+		((dir) => {
+			fs.rmSync(dir, { recursive: true, force: true });
+		});
+
+	if (!fs.existsSync(options.binaryPath)) {
+		logger.error(`Binary not found: ${options.binaryPath}`);
+		logger.error("Build it first with: pnpm build:binary");
+		return {
+			passed: false,
+			results: [
+				{
+					name: "binary exists",
+					passed: false,
+					detail: options.binaryPath,
+				},
+			],
+		};
+	}
+
+	ensureExecutable(options.binaryPath, platform);
+
+	logger.log(`Docula binary harness`);
+	logger.log(`  binary: ${options.binaryPath}`);
+	logger.log("");
+
+	const workDir = mkdtemp("docula-binary-harness-");
+	const results: CheckResult[] = [];
+
+	try {
+		const checks = [
+			() => checkVersion(options.binaryPath, expectedVersion, runCommand),
+			() => checkHelp(options.binaryPath, runCommand),
+			() => checkBuild(options.binaryPath, workDir, runCommand),
+			() =>
+				checkTypescriptConfigRejected(options.binaryPath, workDir, runCommand),
+			() => checkDownloadVariables(options.binaryPath, workDir, runCommand),
+			() => checkInit(options.binaryPath, workDir, runCommand),
+		];
+
+		for (const check of checks) {
+			const result = await check();
+			results.push(result);
+			if (result.passed) {
+				logger.log(
+					`  \u2713 ${result.name}${result.detail ? ` (${result.detail})` : ""}`,
+				);
+			} else {
+				logger.error(`  \u2717 ${result.name}`);
+				if (result.detail) {
+					logger.error(`    ${result.detail}`);
+				}
+			}
+		}
+	} finally {
+		rm(workDir);
+	}
+
+	const failed = results.filter((result) => !result.passed).length;
+	const passed = results.length - failed;
+	logger.log("");
+	if (failed === 0) {
+		logger.log(`${passed} passed`);
+	} else {
+		logger.error(`${passed} passed, ${failed} failed`);
+	}
+
+	return { passed: failed === 0, results };
+}
+
+export async function main(
+	argv: string[] = process.argv.slice(2),
+	env: NodeJS.ProcessEnv = process.env,
+	harness = runBinaryHarness,
+): Promise<number> {
+	if (argv.includes("--help") || argv.includes("-h")) {
+		console.log("Usage: pnpm test:binary [-- /path/to/docula]");
+		console.log("   or: DOCULA_BINARY=/path/to/docula pnpm test:binary");
+		return 0;
+	}
+
+	const binaryPath = resolveBinaryPath(argv, env);
+	const { passed } = await harness({ binaryPath });
+	return passed ? 0 : 1;
+}
+
+const isDirectRun =
+	process.argv[1] !== undefined &&
+	import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+/* v8 ignore next 5 -- @preserve */
+if (isDirectRun) {
+	main()
+		.then((code) => {
+			process.exit(code);
+		})
+		.catch((error: unknown) => {
+			console.error(error);
+			process.exit(1);
+		});
+}

--- a/scripts/test-binary.ts
+++ b/scripts/test-binary.ts
@@ -1,6 +1,5 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
@@ -71,6 +70,25 @@ export function resolveBinaryPath(
 
 export function combinedOutput(result: CommandResult): string {
 	return `${result.stdout}\n${result.stderr}`;
+}
+
+/**
+ * Docula joins CLI paths with `path.join(cwd, value)`, which prefixes
+ * absolute paths (`/tmp/site` becomes `$cwd/tmp/site`). Always pass
+ * paths relative to the process cwd.
+ */
+export function toCliPath(absolutePath: string, cwd = process.cwd()): string {
+	const relative = path.relative(cwd, absolutePath);
+	if (relative === "") {
+		return ".";
+	}
+	return relative;
+}
+
+export function createWorkDir(cwd = process.cwd()): string {
+	const root = path.join(cwd, "tmp");
+	fs.mkdirSync(root, { recursive: true });
+	return fs.mkdtempSync(path.join(root, "docula-binary-harness-"));
 }
 
 export async function runBinaryCommand(
@@ -232,9 +250,9 @@ async function checkBuild(
 	const result = await runCommand(binaryPath, [
 		"build",
 		"-s",
-		siteDir,
+		toCliPath(siteDir),
 		"-o",
-		outputDir,
+		toCliPath(outputDir),
 	]);
 	if (result.exitCode !== 0) {
 		return {
@@ -289,9 +307,9 @@ async function checkTypescriptConfigRejected(
 	const result = await runCommand(binaryPath, [
 		"build",
 		"-s",
-		siteDir,
+		toCliPath(siteDir),
 		"-o",
-		outputDir,
+		toCliPath(outputDir),
 	]);
 	const output = stripAnsi(combinedOutput(result));
 	if (result.exitCode === 0) {
@@ -326,7 +344,7 @@ async function checkDownloadVariables(
 		"download",
 		"variables",
 		"-s",
-		siteDir,
+		toCliPath(siteDir),
 	]);
 	if (result.exitCode !== 0) {
 		return {
@@ -359,7 +377,7 @@ async function checkInit(
 		"init",
 		"--javascript",
 		"-s",
-		siteDir,
+		toCliPath(siteDir),
 	]);
 	if (result.exitCode !== 0) {
 		return {
@@ -398,9 +416,7 @@ export async function runBinaryHarness(
 	const runCommand = options.runCommand ?? runBinaryCommand;
 	const expectedVersion = options.expectedVersion ?? doculaPkg.version;
 	const platform = options.platform ?? process.platform;
-	const mkdtemp =
-		options.mkdtemp ??
-		((prefix) => fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+	const mkdtemp = options.mkdtemp ?? ((_prefix) => createWorkDir());
 	const rm =
 		options.rm ??
 		((dir) => {

--- a/site/docs/binary-download.md
+++ b/site/docs/binary-download.md
@@ -26,6 +26,8 @@ chmod +x docula-linux-x64
 ./docula-linux-x64 version
 ```
 
+In this repository, `pnpm test:binary` runs the same smoke checks the release workflow uses (`version`, `help`, a JSON-config build, TypeScript-config rejection, `download variables`, and `init`). Point it at a downloaded artifact with `DOCULA_BINARY` or a path argument.
+
 ## JSON Config Only
 
 The standalone binary loads configuration from **`docula.config.json`** only. TypeScript (`.ts`) and ESM JavaScript (`.mjs`) config files are not supported when running the binary; if one is present and no `docula.config.json` exists, the binary exits with an error explaining the limitation.

--- a/src/template-resolver.ts
+++ b/src/template-resolver.ts
@@ -8,16 +8,23 @@ let embeddedTemplates: Record<string, string> | undefined;
 /**
  * Registers embedded template data for use in SEA builds.
  * Must be called before any template resolution occurs.
+ * Pass `undefined` to clear the registry (used by tests).
  */
-export function setEmbeddedTemplates(templates: Record<string, string>): void {
+export function setEmbeddedTemplates(
+	templates: Record<string, string> | undefined,
+): void {
 	embeddedTemplates = templates;
 }
 
 /**
- * Returns true when running as a single-executable application (SEA).
+ * Returns true when running as a standalone binary.
+ *
+ * Node's `sea.isSea()` is the official signal, but tsdown's `exe` wrapper
+ * does not always report SEA. `sea-entry` always registers embedded
+ * templates, so a populated registry is treated as the same mode.
  */
 export function isSEA(): boolean {
-	return sea.isSea();
+	return sea.isSea() || embeddedTemplates !== undefined;
 }
 
 /**

--- a/test/template-resolver.test.ts
+++ b/test/template-resolver.test.ts
@@ -53,7 +53,7 @@ describe("template-resolver", () => {
 				existsSpy.mockRestore();
 				isSeaSpy.mockRestore();
 				fs.rmSync(tmpDir, { recursive: true, force: true });
-				setEmbeddedTemplates(undefined as unknown as Record<string, string>);
+				setEmbeddedTemplates(undefined);
 			}
 		});
 	});
@@ -95,7 +95,7 @@ describe("template-resolver", () => {
 
 	describe("setEmbeddedTemplates", () => {
 		afterEach(() => {
-			setEmbeddedTemplates(undefined as unknown as Record<string, string>);
+			setEmbeddedTemplates(undefined);
 		});
 
 		it("should accept a templates record", () => {
@@ -117,6 +117,15 @@ describe("template-resolver", () => {
 		it("should return true when sea.isSea() reports true", () => {
 			vi.spyOn(sea, "isSea").mockReturnValue(true);
 			expect(isSEA()).toBe(true);
+		});
+
+		it("should return true when embedded templates are registered", () => {
+			setEmbeddedTemplates({ "modern/home.hbs": "dGVzdA==" });
+			try {
+				expect(isSEA()).toBe(true);
+			} finally {
+				setEmbeddedTemplates(undefined);
+			}
 		});
 	});
 
@@ -160,7 +169,7 @@ describe("template-resolver", () => {
 
 		afterEach(() => {
 			fs.rmSync(tmpDir, { recursive: true, force: true });
-			setEmbeddedTemplates(undefined as unknown as Record<string, string>);
+			setEmbeddedTemplates(undefined);
 		});
 
 		it("should throw when embedded templates are not registered", () => {

--- a/test/test-binary.test.ts
+++ b/test/test-binary.test.ts
@@ -1,0 +1,627 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	type CommandResult,
+	combinedOutput,
+	defaultBinaryName,
+	main,
+	type RunCommand,
+	resolveBinaryPath,
+	runBinaryCommand,
+	runBinaryHarness,
+	SMOKE_SITE_TITLE,
+	stripAnsi,
+	writeSmokeSite,
+	writeTypescriptOnlySite,
+} from "../scripts/test-binary.js";
+import { makeTempDir } from "./test-helpers.js";
+
+function success(stdout = "", stderr = ""): CommandResult {
+	return { exitCode: 0, stdout, stderr };
+}
+
+function failure(stdout = "", stderr = "boom", exitCode = 1): CommandResult {
+	return { exitCode, stdout, stderr };
+}
+
+function writeBuildOutput(outputDir: string, title = SMOKE_SITE_TITLE): void {
+	fs.mkdirSync(outputDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(outputDir, "index.html"),
+		`<html><title>${title}</title></html>`,
+	);
+	fs.writeFileSync(path.join(outputDir, "robots.txt"), "User-agent: *\n");
+	fs.writeFileSync(path.join(outputDir, "sitemap.xml"), "<urlset></urlset>\n");
+}
+
+function createFakeBinary(): string {
+	const dir = makeTempDir("binary-harness");
+	const binaryPath = path.join(dir, "docula");
+	fs.writeFileSync(binaryPath, "#!/bin/sh\n");
+	return binaryPath;
+}
+
+function runnerFor(
+	handlers: Record<string, (args: string[]) => CommandResult | undefined>,
+): RunCommand {
+	return async (_binaryPath, args) => {
+		const command = args[0] ?? "";
+		const handler = handlers[command];
+		if (!handler) {
+			return failure("", `unexpected command: ${command}`);
+		}
+		return handler(args) ?? success();
+	};
+}
+
+describe("binary harness helpers", () => {
+	it("strips ANSI color codes", () => {
+		expect(stripAnsi("\u001B[32m2.2.0\u001B[0m")).toBe("2.2.0");
+	});
+
+	it("joins stdout and stderr", () => {
+		expect(combinedOutput({ exitCode: 1, stdout: "out", stderr: "err" })).toBe(
+			"out\nerr",
+		);
+	});
+
+	it("picks the platform-specific default binary name", () => {
+		expect(defaultBinaryName("linux")).toBe("docula");
+		expect(defaultBinaryName("darwin")).toBe("docula");
+		expect(defaultBinaryName("win32")).toBe("docula.exe");
+	});
+
+	it("resolves the binary from argv, env, then the default dist path", () => {
+		expect(resolveBinaryPath(["./custom"], {}, "linux", "/repo")).toBe(
+			path.resolve("/repo", "./custom"),
+		);
+		expect(
+			resolveBinaryPath([], { DOCULA_BINARY: "/abs/docula" }, "linux", "/repo"),
+		).toBe("/abs/docula");
+		expect(resolveBinaryPath([], {}, "linux", "/repo")).toBe(
+			path.resolve("/repo", "dist/docula"),
+		);
+		expect(resolveBinaryPath([], {}, "win32", "/repo")).toBe(
+			path.resolve("/repo", "dist/docula.exe"),
+		);
+	});
+
+	it("ignores a bare -- argv token when resolving the binary", () => {
+		expect(resolveBinaryPath(["--"], {}, "linux", "/repo")).toBe(
+			path.resolve("/repo", "dist/docula"),
+		);
+	});
+
+	it("writes the smoke and TypeScript-only sites", () => {
+		const smokeDir = makeTempDir("smoke-site");
+		writeSmokeSite(smokeDir);
+		expect(
+			JSON.parse(
+				fs.readFileSync(path.join(smokeDir, "docula.config.json"), "utf8"),
+			).siteTitle,
+		).toBe(SMOKE_SITE_TITLE);
+		expect(fs.existsSync(path.join(smokeDir, "README.md"))).toBe(true);
+
+		const tsDir = makeTempDir("ts-site");
+		writeTypescriptOnlySite(tsDir);
+		expect(fs.existsSync(path.join(tsDir, "docula.config.ts"))).toBe(true);
+		expect(fs.existsSync(path.join(tsDir, "docula.config.json"))).toBe(false);
+	});
+});
+
+describe("runBinaryCommand", () => {
+	it("captures stdout from a successful process", async () => {
+		const result = await runBinaryCommand(process.execPath, [
+			"-e",
+			"console.log('ok')",
+		]);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("ok");
+	});
+
+	it("captures a non-zero exit code", async () => {
+		const result = await runBinaryCommand(process.execPath, [
+			"-e",
+			"console.error('nope'); process.exit(2)",
+		]);
+		expect(result.exitCode).toBe(2);
+		expect(result.stderr).toContain("nope");
+	});
+
+	it("rejects when the process cannot be spawned", async () => {
+		await expect(
+			runBinaryCommand(path.join(makeTempDir("missing"), "no-such-binary"), [
+				"version",
+			]),
+		).rejects.toThrow();
+	});
+
+	it("rejects when the command times out", async () => {
+		await expect(
+			runBinaryCommand(
+				process.execPath,
+				["-e", "setTimeout(() => {}, 10_000)"],
+				{ timeoutMs: 50 },
+			),
+		).rejects.toThrow(/Timed out/);
+	});
+});
+
+describe("runBinaryHarness", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("fails when the binary is missing", async () => {
+		const errors: string[] = [];
+		const result = await runBinaryHarness({
+			binaryPath: path.join(makeTempDir("missing"), "docula"),
+			logger: {
+				log: () => undefined,
+				error: (message) => {
+					errors.push(message);
+				},
+			},
+		});
+
+		expect(result.passed).toBe(false);
+		expect(result.results[0]?.name).toBe("binary exists");
+		expect(errors.some((message) => message.includes("Binary not found"))).toBe(
+			true,
+		);
+	});
+
+	it("makes a non-executable unix binary executable", async () => {
+		const binaryPath = createFakeBinary();
+		fs.chmodSync(binaryPath, 0o644);
+
+		const result = await runBinaryHarness({
+			binaryPath,
+			expectedVersion: "9.9.9",
+			platform: "linux",
+			runCommand: runnerFor({
+				version: () => success("9.9.9\n"),
+				help: () => success("Usage:\n  build\n"),
+				build: (args) => {
+					const outputDir = args[args.indexOf("-o") + 1];
+					writeBuildOutput(outputDir);
+					return success();
+				},
+				download: (args) => {
+					const siteDir = args[args.indexOf("-s") + 1];
+					fs.writeFileSync(path.join(siteDir, "variables.css"), ":root {}\n");
+					return success();
+				},
+				init: (args) => {
+					const siteDir = args[args.indexOf("-s") + 1];
+					fs.mkdirSync(siteDir, { recursive: true });
+					fs.writeFileSync(
+						path.join(siteDir, "docula.config.mjs"),
+						"export {}\n",
+					);
+					fs.writeFileSync(path.join(siteDir, "logo.png"), "logo");
+					fs.writeFileSync(path.join(siteDir, "favicon.ico"), "ico");
+					return success();
+				},
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(result.passed).toBe(true);
+		expect((fs.statSync(binaryPath).mode & 0o111) !== 0).toBe(true);
+	});
+
+	it("skips chmod on Windows", async () => {
+		const binaryPath = createFakeBinary();
+		const chmod = vi.spyOn(fs, "chmodSync");
+
+		await runBinaryHarness({
+			binaryPath,
+			expectedVersion: "1.0.0",
+			platform: "win32",
+			runCommand: async () => failure("nope"),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(chmod).not.toHaveBeenCalled();
+	});
+
+	it("fails version when the process exits non-zero", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			runCommand: runnerFor({
+				version: () => failure("", "bad version"),
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(result.results.find((item) => item.name === "version")?.passed).toBe(
+			false,
+		);
+	});
+
+	it("fails version when the printed version does not match", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "2.2.0",
+			runCommand: runnerFor({
+				version: () => success("0.0.1\n"),
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(
+			result.results.find((item) => item.name === "version")?.detail,
+		).toContain('expected "2.2.0"');
+	});
+
+	it("fails help when the process exits non-zero", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "1.0.0",
+			runCommand: runnerFor({
+				version: () => success("1.0.0\n"),
+				help: () => failure("", "no help"),
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(result.results.find((item) => item.name === "help")?.passed).toBe(
+			false,
+		);
+	});
+
+	it("fails help when usage text is missing", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "1.0.0",
+			runCommand: runnerFor({
+				version: () => success("1.0.0\n"),
+				help: () => success("nothing useful"),
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(
+			result.results.find((item) => item.name === "help")?.detail,
+		).toContain("Usage");
+	});
+
+	it("fails build when the process exits non-zero", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "1.0.0",
+			runCommand: runnerFor({
+				version: () => success("1.0.0\n"),
+				help: () => success("Usage:\n  build\n"),
+				build: () => failure("", "build exploded"),
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(result.results.find((item) => item.name === "build")?.passed).toBe(
+			false,
+		);
+	});
+
+	it("fails build when index.html is missing", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "1.0.0",
+			runCommand: runnerFor({
+				version: () => success("1.0.0\n"),
+				help: () => success("Usage:\n  build\n"),
+				build: () => success(),
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(
+			result.results.find((item) => item.name === "build")?.detail,
+		).toContain("missing");
+	});
+
+	it("fails build when the site title is missing from index.html", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "1.0.0",
+			runCommand: runnerFor({
+				version: () => success("1.0.0\n"),
+				help: () => success("Usage:\n  build\n"),
+				build: (args) => {
+					const outputDir = args[args.indexOf("-o") + 1];
+					writeBuildOutput(outputDir, "Wrong Title");
+					return success();
+				},
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(
+			result.results.find((item) => item.name === "build")?.detail,
+		).toContain(SMOKE_SITE_TITLE);
+	});
+
+	it("fails build when generated SEO files are missing", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "1.0.0",
+			runCommand: runnerFor({
+				version: () => success("1.0.0\n"),
+				help: () => success("Usage:\n  build\n"),
+				build: (args) => {
+					const outputDir = args[args.indexOf("-o") + 1];
+					fs.mkdirSync(outputDir, { recursive: true });
+					fs.writeFileSync(
+						path.join(outputDir, "index.html"),
+						`<html><title>${SMOKE_SITE_TITLE}</title></html>`,
+					);
+					return success();
+				},
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(
+			result.results.find((item) => item.name === "build")?.detail,
+		).toContain("robots.txt");
+	});
+
+	it("fails when a TypeScript-only config is accepted", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "1.0.0",
+			runCommand: runnerFor({
+				version: () => success("1.0.0\n"),
+				help: () => success("Usage:\n  build\n"),
+				build: (args) => {
+					if (args.includes("ts-only-site")) {
+						return success();
+					}
+					const outputDir = args[args.indexOf("-o") + 1];
+					writeBuildOutput(outputDir);
+					return success();
+				},
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(
+			result.results.find((item) => item.name === "json-only config")?.passed,
+		).toBe(false);
+	});
+
+	it("fails when the TypeScript-config error does not mention JSON", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "1.0.0",
+			runCommand: runnerFor({
+				version: () => success("1.0.0\n"),
+				help: () => success("Usage:\n  build\n"),
+				build: (args) => {
+					if (args.includes("ts-only-site")) {
+						return failure("", "something else went wrong");
+					}
+					const outputDir = args[args.indexOf("-o") + 1];
+					writeBuildOutput(outputDir);
+					return success();
+				},
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(
+			result.results.find((item) => item.name === "json-only config")?.detail,
+		).toContain("docula.config.json");
+	});
+
+	it("fails download variables when the process exits non-zero", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "1.0.0",
+			runCommand: runnerFor({
+				version: () => success("1.0.0\n"),
+				help: () => success("Usage:\n  build\n"),
+				build: (args) => {
+					if (args.includes("ts-only-site")) {
+						return failure("", "Only docula.config.json is supported");
+					}
+					const outputDir = args[args.indexOf("-o") + 1];
+					writeBuildOutput(outputDir);
+					return success();
+				},
+				download: () => failure("", "download failed"),
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(
+			result.results.find((item) => item.name === "download variables")?.passed,
+		).toBe(false);
+	});
+
+	it("fails download variables when variables.css is missing", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "1.0.0",
+			runCommand: runnerFor({
+				version: () => success("1.0.0\n"),
+				help: () => success("Usage:\n  build\n"),
+				build: (args) => {
+					if (args.includes("ts-only-site")) {
+						return failure("", "Only docula.config.json is supported");
+					}
+					const outputDir = args[args.indexOf("-o") + 1];
+					writeBuildOutput(outputDir);
+					return success();
+				},
+				download: () => success(),
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(
+			result.results.find((item) => item.name === "download variables")?.detail,
+		).toContain("variables.css");
+	});
+
+	it("fails init when the process exits non-zero", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "1.0.0",
+			runCommand: runnerFor({
+				version: () => success("1.0.0\n"),
+				help: () => success("Usage:\n  build\n"),
+				build: (args) => {
+					if (args.includes("ts-only-site")) {
+						return failure("", "Only docula.config.json is supported");
+					}
+					const outputDir = args[args.indexOf("-o") + 1];
+					writeBuildOutput(outputDir);
+					return success();
+				},
+				download: (args) => {
+					const siteDir = args[args.indexOf("-s") + 1];
+					fs.writeFileSync(path.join(siteDir, "variables.css"), ":root {}\n");
+					return success();
+				},
+				init: () => failure("", "init failed"),
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(result.results.find((item) => item.name === "init")?.passed).toBe(
+			false,
+		);
+	});
+
+	it("fails init when scaffold files are missing", async () => {
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "1.0.0",
+			runCommand: runnerFor({
+				version: () => success("1.0.0\n"),
+				help: () => success("Usage:\n  build\n"),
+				build: (args) => {
+					if (args.includes("ts-only-site")) {
+						return failure("", "Only docula.config.json is supported");
+					}
+					const outputDir = args[args.indexOf("-o") + 1];
+					writeBuildOutput(outputDir);
+					return success();
+				},
+				download: (args) => {
+					const siteDir = args[args.indexOf("-s") + 1];
+					fs.writeFileSync(path.join(siteDir, "variables.css"), ":root {}\n");
+					return success();
+				},
+				init: () => success(),
+			}),
+			logger: { log: () => undefined, error: () => undefined },
+		});
+
+		expect(
+			result.results.find((item) => item.name === "init")?.detail,
+		).toContain("docula.config.mjs");
+	});
+
+	it("passes every check when the binary behaves", async () => {
+		const logs: string[] = [];
+		const result = await runBinaryHarness({
+			binaryPath: createFakeBinary(),
+			expectedVersion: "2.2.0",
+			runCommand: runnerFor({
+				version: () => success("\u001B[32m2.2.0\u001B[0m\n"),
+				help: () => success("Usage:\n    docula [command]\n    build\n"),
+				build: (args) => {
+					if (args.includes("ts-only-site")) {
+						return failure(
+							"",
+							"Only docula.config.json is supported when running the standalone binary",
+						);
+					}
+					const outputDir = args[args.indexOf("-o") + 1];
+					writeBuildOutput(outputDir);
+					return success();
+				},
+				download: (args) => {
+					const siteDir = args[args.indexOf("-s") + 1];
+					fs.writeFileSync(path.join(siteDir, "variables.css"), ":root {}\n");
+					return success();
+				},
+				init: (args) => {
+					const siteDir = args[args.indexOf("-s") + 1];
+					fs.mkdirSync(siteDir, { recursive: true });
+					fs.writeFileSync(
+						path.join(siteDir, "docula.config.mjs"),
+						"export {}\n",
+					);
+					fs.writeFileSync(path.join(siteDir, "logo.png"), "logo");
+					fs.writeFileSync(path.join(siteDir, "favicon.ico"), "ico");
+					return success();
+				},
+			}),
+			logger: {
+				log: (message) => {
+					logs.push(message);
+				},
+				error: () => undefined,
+			},
+		});
+
+		expect(result.passed).toBe(true);
+		expect(result.results).toHaveLength(6);
+		expect(logs.some((message) => message.includes("6 passed"))).toBe(true);
+	});
+
+	it("cleans up the work directory even when a check throws", async () => {
+		const workDir = makeTempDir("harness-work");
+		const rm = vi.fn();
+
+		await expect(
+			runBinaryHarness({
+				binaryPath: createFakeBinary(),
+				mkdtemp: () => workDir,
+				rm,
+				runCommand: async () => {
+					throw new Error("runner exploded");
+				},
+				logger: { log: () => undefined, error: () => undefined },
+			}),
+		).rejects.toThrow("runner exploded");
+
+		expect(rm).toHaveBeenCalledWith(workDir);
+	});
+});
+
+describe("main", () => {
+	it("prints harness usage and exits 0", async () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+		await expect(main(["--help"])).resolves.toBe(0);
+		await expect(main(["-h"])).resolves.toBe(0);
+		expect(log).toHaveBeenCalled();
+		log.mockRestore();
+	});
+
+	it("returns 0 when the harness passes", async () => {
+		const harness = vi.fn(async () => ({
+			passed: true,
+			results: [{ name: "version", passed: true }],
+		}));
+		await expect(main(["./dist/docula"], {}, harness)).resolves.toBe(0);
+		expect(harness).toHaveBeenCalledWith({
+			binaryPath: path.resolve(process.cwd(), "./dist/docula"),
+		});
+	});
+
+	it("returns 1 when the harness fails", async () => {
+		const harness = vi.fn(async () => ({
+			passed: false,
+			results: [{ name: "version", passed: false }],
+		}));
+		await expect(
+			main([], { DOCULA_BINARY: "/tmp/docula" }, harness),
+		).resolves.toBe(1);
+	});
+});

--- a/test/test-binary.test.ts
+++ b/test/test-binary.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	type CommandResult,
 	combinedOutput,
+	createWorkDir,
 	defaultBinaryName,
 	main,
 	type RunCommand,
@@ -12,6 +13,7 @@ import {
 	runBinaryHarness,
 	SMOKE_SITE_TITLE,
 	stripAnsi,
+	toCliPath,
 	writeSmokeSite,
 	writeTypescriptOnlySite,
 } from "../scripts/test-binary.js";
@@ -55,6 +57,38 @@ function runnerFor(
 	};
 }
 
+function isTypescriptOnlyBuild(args: string[]): boolean {
+	return args.some((argument) => argument.includes("ts-only-site"));
+}
+
+function passingRunner(): RunCommand {
+	return runnerFor({
+		version: () => success("1.0.0\n"),
+		help: () => success("Usage:\n  build\n"),
+		build: (args) => {
+			if (isTypescriptOnlyBuild(args)) {
+				return failure("", "Only docula.config.json is supported");
+			}
+			const outputDir = args[args.indexOf("-o") + 1];
+			writeBuildOutput(outputDir);
+			return success();
+		},
+		download: (args) => {
+			const siteDir = args[args.indexOf("-s") + 1];
+			fs.writeFileSync(path.join(siteDir, "variables.css"), ":root {}\n");
+			return success();
+		},
+		init: (args) => {
+			const siteDir = args[args.indexOf("-s") + 1];
+			fs.mkdirSync(siteDir, { recursive: true });
+			fs.writeFileSync(path.join(siteDir, "docula.config.mjs"), "export {}\n");
+			fs.writeFileSync(path.join(siteDir, "logo.png"), "logo");
+			fs.writeFileSync(path.join(siteDir, "favicon.ico"), "ico");
+			return success();
+		},
+	});
+}
+
 describe("binary harness helpers", () => {
 	it("strips ANSI color codes", () => {
 		expect(stripAnsi("\u001B[32m2.2.0\u001B[0m")).toBe("2.2.0");
@@ -91,6 +125,18 @@ describe("binary harness helpers", () => {
 		expect(resolveBinaryPath(["--"], {}, "linux", "/repo")).toBe(
 			path.resolve("/repo", "dist/docula"),
 		);
+	});
+
+	it("converts absolute paths under cwd to relative CLI paths", () => {
+		expect(toCliPath("/repo/tmp/site", "/repo")).toBe(path.join("tmp", "site"));
+		expect(toCliPath("/repo", "/repo")).toBe(".");
+	});
+
+	it("creates a work directory under cwd/tmp", () => {
+		const dir = createWorkDir();
+		expect(dir.startsWith(path.join(process.cwd(), "tmp"))).toBe(true);
+		expect(fs.existsSync(dir)).toBe(true);
+		fs.rmSync(dir, { recursive: true, force: true });
 	});
 
 	it("writes the smoke and TypeScript-only sites", () => {
@@ -178,33 +224,9 @@ describe("runBinaryHarness", () => {
 
 		const result = await runBinaryHarness({
 			binaryPath,
-			expectedVersion: "9.9.9",
+			expectedVersion: "1.0.0",
 			platform: "linux",
-			runCommand: runnerFor({
-				version: () => success("9.9.9\n"),
-				help: () => success("Usage:\n  build\n"),
-				build: (args) => {
-					const outputDir = args[args.indexOf("-o") + 1];
-					writeBuildOutput(outputDir);
-					return success();
-				},
-				download: (args) => {
-					const siteDir = args[args.indexOf("-s") + 1];
-					fs.writeFileSync(path.join(siteDir, "variables.css"), ":root {}\n");
-					return success();
-				},
-				init: (args) => {
-					const siteDir = args[args.indexOf("-s") + 1];
-					fs.mkdirSync(siteDir, { recursive: true });
-					fs.writeFileSync(
-						path.join(siteDir, "docula.config.mjs"),
-						"export {}\n",
-					);
-					fs.writeFileSync(path.join(siteDir, "logo.png"), "logo");
-					fs.writeFileSync(path.join(siteDir, "favicon.ico"), "ico");
-					return success();
-				},
-			}),
+			runCommand: passingRunner(),
 			logger: { log: () => undefined, error: () => undefined },
 		});
 
@@ -376,7 +398,7 @@ describe("runBinaryHarness", () => {
 				version: () => success("1.0.0\n"),
 				help: () => success("Usage:\n  build\n"),
 				build: (args) => {
-					if (args.includes("ts-only-site")) {
+					if (isTypescriptOnlyBuild(args)) {
 						return success();
 					}
 					const outputDir = args[args.indexOf("-o") + 1];
@@ -400,7 +422,7 @@ describe("runBinaryHarness", () => {
 				version: () => success("1.0.0\n"),
 				help: () => success("Usage:\n  build\n"),
 				build: (args) => {
-					if (args.includes("ts-only-site")) {
+					if (isTypescriptOnlyBuild(args)) {
 						return failure("", "something else went wrong");
 					}
 					const outputDir = args[args.indexOf("-o") + 1];
@@ -424,7 +446,7 @@ describe("runBinaryHarness", () => {
 				version: () => success("1.0.0\n"),
 				help: () => success("Usage:\n  build\n"),
 				build: (args) => {
-					if (args.includes("ts-only-site")) {
+					if (isTypescriptOnlyBuild(args)) {
 						return failure("", "Only docula.config.json is supported");
 					}
 					const outputDir = args[args.indexOf("-o") + 1];
@@ -449,7 +471,7 @@ describe("runBinaryHarness", () => {
 				version: () => success("1.0.0\n"),
 				help: () => success("Usage:\n  build\n"),
 				build: (args) => {
-					if (args.includes("ts-only-site")) {
+					if (isTypescriptOnlyBuild(args)) {
 						return failure("", "Only docula.config.json is supported");
 					}
 					const outputDir = args[args.indexOf("-o") + 1];
@@ -474,7 +496,7 @@ describe("runBinaryHarness", () => {
 				version: () => success("1.0.0\n"),
 				help: () => success("Usage:\n  build\n"),
 				build: (args) => {
-					if (args.includes("ts-only-site")) {
+					if (isTypescriptOnlyBuild(args)) {
 						return failure("", "Only docula.config.json is supported");
 					}
 					const outputDir = args[args.indexOf("-o") + 1];
@@ -504,7 +526,7 @@ describe("runBinaryHarness", () => {
 				version: () => success("1.0.0\n"),
 				help: () => success("Usage:\n  build\n"),
 				build: (args) => {
-					if (args.includes("ts-only-site")) {
+					if (isTypescriptOnlyBuild(args)) {
 						return failure("", "Only docula.config.json is supported");
 					}
 					const outputDir = args[args.indexOf("-o") + 1];
@@ -535,7 +557,7 @@ describe("runBinaryHarness", () => {
 				version: () => success("\u001B[32m2.2.0\u001B[0m\n"),
 				help: () => success("Usage:\n    docula [command]\n    build\n"),
 				build: (args) => {
-					if (args.includes("ts-only-site")) {
+					if (isTypescriptOnlyBuild(args)) {
 						return failure(
 							"",
 							"Only docula.config.json is supported when running the standalone binary",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Test infrastructure for standalone binaries, plus a SEA-detection fix the harness uncovered.

The release workflow previously inlined a three-line smoke check. This extracts that into a reusable harness (`pnpm test:binary`) that validates a built or downloaded binary:

- `version` matches `package.json`
- `help` prints usage
- `build` of a JSON-only smoke site writes `index.html`, `robots.txt`, and `sitemap.xml`
- TypeScript-only configs are rejected (SEA JSON-only limitation)
- `download variables` writes `variables.css` from the embedded templates
- `init --javascript` scaffolds config, logo, and favicon

The `build-binaries` workflow now runs `pnpm test:binary` instead of the inline script. Unit tests cover the harness with a mocked runner so regular `pnpm test` does not need a SEA binary.

While running the harness against a locally built `dist/docula`, two issues showed up and are fixed here:

1. **SEA detection** — tsdown's `exe` wrapper does not always make `sea.isSea()` return true. `isSEA()` now also treats registered embedded templates (set by `sea-entry`) as standalone mode, so JSON-only config enforcement and embedded templates work.
2. **CLI paths** — Docula joins `-s`/`-o` with `path.join(cwd, value)`, which turns `/tmp/site` into `$cwd/tmp/site`. The harness passes cwd-relative paths.

Validated with `pnpm test` (866 tests, 100% coverage) and `pnpm test:binary -- ./dist/docula` (6 passed) on a Node 26 SEA build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00d2f-894e-7fda-9e4d-579aadbcd4aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00d2f-894e-7fda-9e4d-579aadbcd4aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

