### PR TITLE
fix: pin liquidjs to 10.27.1 for memoryLimit DoS advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   undici@>=8.0.0 <8.9.0: 8.10.0
   undici@>=7.0.0 <7.29.0: 7.29.0
+  liquidjs@<10.27.1: 10.27.1
 
 importers:
 
@@ -1718,8 +1719,8 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
-  liquidjs@10.27.0:
-    resolution: {integrity: sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==}
+  liquidjs@10.27.1:
+    resolution: {integrity: sha512-ylE+1q2kSef1UxAyxqbyuWM3FRWS1v48JK1Y3CoW3bD6TSNXZh0+GsVnihujEpKyR+Jejx2aRAFfC3AHm9rElg==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -3472,7 +3473,7 @@ snapshots:
       cacheable: 2.5.0
       ejs: 6.0.1
       hookified: 3.0.1
-      liquidjs: 10.27.0
+      liquidjs: 10.27.1
       nunjucks: 3.2.4
       pug: 3.0.4
       writr: 6.1.5(supports-color@7.2.0)
@@ -3932,7 +3933,7 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  liquidjs@10.27.0:
+  liquidjs@10.27.1:
     dependencies:
       commander: 10.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,9 +12,13 @@ allowBuilds:
 
 # Force every undici copy onto a release that includes the SOCKS5
 # requestTls fix (8.5.0 / 7.28.0) and the later 8.9.0 / 7.29.0 advisories.
+# Force liquidjs onto 10.27.1+ so ecto's ^10.27.0 range cannot resolve
+# 10.27.0 (CVE-2026-55575 / AIKIDO-2026-127306: pop/sample filters
+# bypass memoryLimit accounting and allow a DoS).
 overrides:
   "undici@>=8.0.0 <8.9.0": "8.10.0"
   "undici@>=7.0.0 <7.29.0": "7.29.0"
+  "liquidjs@<10.27.1": "10.27.1"
 
 minimumReleaseAgeExclude:
   - writr


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Security dependency fix.

**Why this change is needed**

Aikido reported two `liquidjs` advisories in `pnpm-lock.yaml`:

- **CVE-2026-55575** (High): `pop` filter clones arrays without charging `memoryLimit`
- **AIKIDO-2026-127306** (Medium): `pop`/`sample` filters bypass `memoryLimit` accounting

Worst-case impact is a denial-of-service via unbounded memory allocation. Both are fixed in `liquidjs` 10.27.1.

`liquidjs` is a transitive dependency of `ecto` (`^10.27.0`), which had resolved to 10.27.0.

**What this PR does**

Adds a pnpm override (same pattern as the existing `undici` pins) so any `liquidjs` below 10.27.1 is forced to 10.27.1, and updates the lockfile accordingly.

No application source changes. Existing tests cover template rendering through `ecto`.

**Verification**

- `pnpm why liquidjs` reports a single copy: `liquidjs@10.27.1` via `ecto@5.0.0`
- `pnpm test`: 17 files / 866 tests passed, 100% statement/branch/function/line coverage

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a81e4a17-10ac-45a2-8220-b4600ef8bf0e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a81e4a17-10ac-45a2-8220-b4600ef8bf0e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

