### PR TITLE
fix: prefix staged tarball path so npm does not treat it as git

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,4 +90,7 @@ jobs:
       run: sfw npm install --global npm@11.19.0
 
     - name: Stage publish
-      run: npm stage publish packed/*.tgz --access public --provenance
+      # Prefix with ./ so npm treats the tarball as a local file. A bare
+      # packed/*.tgz path is parsed as GitHub owner/repo shorthand (npm npa),
+      # which then fails with git ls-remote Permission denied (publickey).
+      run: npm stage publish ./packed/*.tgz --access public --provenance


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for the release workflow.

**Why this change is needed?**
The v3.0.0 release failed at the Stage publish step ([run 32056846194](https://github.com/jaredwray/docula/actions/runs/32056846194/job/95469616116)) with:

```
npm error command git --no-replace-objects ls-remote ssh://git@github.com/packed/docula-3.0.0.tgz.git
npm error git@github.com: Permission denied (publickey).
```

This is not an OIDC / trusted-publisher problem. The trusted publisher is already configured for `release.yaml` with `npm stage publish`. npm 11+ (`npm-package-arg`) parses a bare `dir/file.tgz` argument as GitHub `owner/repo` shorthand, so `packed/docula-3.0.0.tgz` became `github:packed/docula-3.0.0.tgz`.

**What this PR does**
Prefixes the packed tarball glob with `./` so npa treats it as a local file:

```
npm stage publish ./packed/*.tgz --access public --provenance
```

Reproduced locally with the same npm 11.19.0 the workflow installs:
- `npm stage publish packed/*.tgz --dry-run` → exit 128, `git ls-remote ssh://git@github.com/packed/docula-repro-dummy-3.0.0.tgz.git`
- `npm stage publish ./packed/*.tgz --dry-run` → exit 0, `Staging ... (dry-run)`

`pnpm test`: 17 files, 866 tests passed, 100% coverage. Workflow-only change; no application source to cover with unit tests.

After merge, re-run the `release` workflow (or re-release) so 3.0.0 can be staged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-944d6213-cb0a-42db-9529-7d3aeccfdb04?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-944d6213-cb0a-42db-9529-7d3aeccfdb04&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

