### PR TITLE
test: make onReleaseChangelog hook error test robust

### DIFF
--- a/test/builder-changelog.test.ts
+++ b/test/builder-changelog.test.ts
@@ -1375,6 +1375,18 @@ describe("DoculaBuilder - Changelog", () => {
 			options.enableReleaseChangelog = true;
 			options.quiet = true;
 			const builder = new DoculaBuilder(options);
+			builder.console.quiet = true;
+			// Inject releases so the hook always runs, independent of the GitHub
+			// HTTP mock module-graph. Stub console.error so the expected log does
+			// not leak to stderr (Vitest reports that as `✘ [error] ...`).
+			vi.spyOn(builder, "getGithubData").mockResolvedValue({
+				releases: githubMockReleases,
+				contributors: githubMockContributors,
+				// biome-ignore lint/suspicious/noExplicitAny: minimal GithubData stub
+			} as any);
+			const errorSpy = vi
+				.spyOn(builder.console, "error")
+				.mockImplementation(() => {});
 
 			builder.onReleaseChangelog = (_entries, _console) => {
 				throw new Error("Hook failed");
@@ -1383,10 +1395,14 @@ describe("DoculaBuilder - Changelog", () => {
 			try {
 				// Should not throw — error is caught and logged
 				await builder.build();
+				expect(errorSpy).toHaveBeenCalledWith(
+					expect.stringContaining("onReleaseChangelog error: Hook failed"),
+				);
 				expect(fs.existsSync(`${options.output}/changelog/index.html`)).toBe(
 					true,
 				);
 			} finally {
+				errorSpy.mockRestore();
 				await fs.promises.rm(options.output, {
 					recursive: true,
 					force: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Test robustness / flake fix.

**Why**
`should handle onReleaseChangelog hook errors gracefully` was leaking the expected hook failure to stderr:

```
stderr | test/builder-changelog.test.ts > ... > should handle onReleaseChangelog hook errors gracefully
✘ [error] onReleaseChangelog error: Hook failed
```

`DoculaConsole.error()` always writes to `console.error` (even in quiet mode), so Vitest reports it as a failed-looking `✘ [error]` line. The test also depended on the GitHub HTTP mock actually supplying releases, so the hook was not guaranteed to run.

**What**
Harden that test in `test/builder-changelog.test.ts`:
- Inject GitHub releases via `getGithubData` so the hook always runs
- Stub `builder.console.error` so the expected log does not leak to stderr
- Assert the error is logged and the changelog page is still built

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-180c0d48-d915-4534-b663-7bc8280616b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-180c0d48-d915-4534-b663-7bc8280616b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

