### PR TITLE
root - chore: defense - drop tilde range preference

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -35,7 +35,6 @@ Profile: npm library · public
 - [x] `blockExoticSubdeps: true` — verified 2026-08-16
 - [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — PR #465
 - [x] Dependency-update tooling opens PRs only — never auto-merge — verified 2026-08-16 (no auto-merge config in-repo; upgrades via reviewed PRs)
-- [x] New direct dependencies get human review; prefer `~` ranges over `^` — verified 2026-08-16 (all changes via PR; existing runtime deps stay on `^`; new runtime deps prefer `~`)
 
 ## 4. GitHub Actions
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Remove the defense-in-depth checklist item that preferred `~` ranges over `^`. This repo uses caret ranges for direct dependencies.

## Status update
`DEFENSE_IN_DEPTH.md`: drop “New direct dependencies get human review; prefer `~` ranges over `^`”.

## How this was checked off
It was marked done in [PR #464](https://github.com/jaredwray/docula/pull/464) when the security-docs scaffold reconciled the [defense-in-depth-nodejs catalog](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/reference.md). The note was:

> verified 2026-08-16 (all changes via PR; existing runtime deps stay on `^`; new runtime deps prefer `~`)

That mixed two things: PRs for dependency changes (true) with a catalog policy this repo does not follow. Every direct dependency in `package.json` already uses `^`. Nothing ever switched new runtime deps to `~`.

## Verification
- [x] `package.json` dependencies and devDependencies all use `^`
- [x] `pnpm test` — 17 files, 866 tests, 100% coverage

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6c62a88-2112-46d5-ae32-ba1b237f73ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6c62a88-2112-46d5-ae32-ba1b237f73ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

